### PR TITLE
Allow empty method names

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -1140,6 +1140,8 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->fiberClass->obj.classObj, "suspend()", fiber_suspend);
   PRIMITIVE(vm->fiberClass->obj.classObj, "yield()", fiber_yield);
   PRIMITIVE(vm->fiberClass->obj.classObj, "yield(_)", fiber_yield1);
+  PRIMITIVE(vm->fiberClass, "()", fiber_call);
+  PRIMITIVE(vm->fiberClass, "(_)", fiber_call1);
   PRIMITIVE(vm->fiberClass, "call()", fiber_call);
   PRIMITIVE(vm->fiberClass, "call(_)", fiber_call1);
   PRIMITIVE(vm->fiberClass, "error", fiber_error);
@@ -1152,6 +1154,23 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->fnClass->obj.classObj, "new(_)", fn_new);
 
   PRIMITIVE(vm->fnClass, "arity", fn_arity);
+  PRIMITIVE(vm->fnClass, "()", fn_call0);
+  PRIMITIVE(vm->fnClass, "(_)", fn_call1);
+  PRIMITIVE(vm->fnClass, "(_,_)", fn_call2);
+  PRIMITIVE(vm->fnClass, "(_,_,_)", fn_call3);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_)", fn_call4);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_)", fn_call5);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_)", fn_call6);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_)", fn_call7);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_)", fn_call8);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_)", fn_call9);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_)", fn_call10);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_,_)", fn_call11);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_,_,_)", fn_call12);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_,_,_,_)", fn_call13);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_,_,_,_,_)", fn_call14);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)", fn_call15);
+  PRIMITIVE(vm->fnClass, "(_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)", fn_call16);
   PRIMITIVE(vm->fnClass, "call()", fn_call0);
   PRIMITIVE(vm->fnClass, "call(_)", fn_call1);
   PRIMITIVE(vm->fnClass, "call(_,_)", fn_call2);

--- a/test/core/fiber/call.wren
+++ b/test/core/fiber/call.wren
@@ -5,3 +5,11 @@ var fiber = Fiber.new {
 System.print("before") // expect: before
 fiber.call()       // expect: fiber
 System.print("after")  // expect: after
+
+var fiber2 = Fiber.new {
+  System.print("fiber2")
+}
+
+System.print("before") // expect: before
+fiber2.()       // expect: fiber2
+System.print("after")  // expect: after

--- a/test/language/function/syntax.wren
+++ b/test/language/function/syntax.wren
@@ -23,3 +23,14 @@ Fn.new {
 
 
 }.call()
+
+// Without .call
+Fn.new { System.print("ok") }.() // expect: ok
+
+// Function returned by method.
+class test {
+  construct new() {}
+  fn { Fn.new { System.print("ok") } }
+}
+
+test.new().fn.() // expect: ok

--- a/test/language/method/empty_name.wren
+++ b/test/language/method/empty_name.wren
@@ -1,0 +1,15 @@
+class EmptyMethodName {
+  construct new() {}
+  () {
+    System.print("Hello World")
+  }
+
+  (a) {
+    System.print(a)
+  }
+}
+
+var fn = EmptyMethodName.new()
+
+fn.() // expect: Hello World
+fn.("foo") // expect: foo

--- a/test/language/method/empty_name_without_argument_list.wren
+++ b/test/language/method/empty_name_without_argument_list.wren
@@ -1,0 +1,4 @@
+var foo = 123
+
+// expect error line 4
+foo.


### PR DESCRIPTION
This is a proposal to get a nicer function call syntax into wren. It is inspired by Elixir and turned out to be pretty easy to implement.

With this pull request, it's possible to define methods like this:

``` dart
class EmptyMethodName {
  construct new() {}
  () {
    System.print("Hello World")
  }

  (a) {
    System.print(a)
  }
}
```

...and then call them like this:

``` dart
var fn = EmptyMethodName.new()
fn.()
fn.("foo")
```

The additional dot avoids ambiguities with getters:

``` dart
class test {
  construct new() {}
  fn { Fn.new { System.print("ok") } }
}
test.new().fn.()
```
