### PR TITLE
Add "as" keyword

### DIFF
--- a/test/language/module/import_as/import_as.wren
+++ b/test/language/module/import_as/import_as.wren
@@ -1,0 +1,4 @@
+import "module" for Module as AnotherName
+// expect: ran module
+
+System.print(AnotherName) // expect: from module

--- a/test/language/module/import_as/module.wren
+++ b/test/language/module/import_as/module.wren
@@ -1,0 +1,3 @@
+// nontest
+var Module = "from module"
+System.print("ran module")


### PR DESCRIPTION
Some tinkering!

- I prefer `as`, it's clearer than `in`, although you could keep `in` and not add a token.
- I like the syntax of `import "io" for File as F, Process as P` it reads nicely
- It's optional, so `import "io" for File as F, Process` is valid

Thoughts welcome!