### PR TITLE
Number conversions

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -537,24 +537,23 @@ DEF_PRIMITIVE(num_fromString)
   if (!validateString(vm, args[1], "Argument")) return false;
 
   ObjString* string = AS_STRING(args[1]);
+  Value number = NULL_VAL;
 
-  // Corner case: Can't parse an empty string.
-  if (string->length == 0) RETURN_NULL;
+  switch (wrenNewNumFromStringLength(string->value, string->length, &number))
+  {
+  case 0:
+    break;
+  case ERANGE:
+    RETURN_ERROR("Number literal is too large.");
+    break;
+  case EINVAL:
+    //RETURN_ERROR("Invalid value.");
+    break;
+  default:
+    RETURN_ERROR("Internal error: Unexpected error.");
+  }
 
-  errno = 0;
-  char* end;
-  double number = strtod(string->value, &end);
-
-  // Skip past any trailing whitespace.
-  end = wrenEatSpace(end, NULL);
-
-  if (errno == ERANGE) RETURN_ERROR("Number literal is too large.");
-
-  // We must have consumed the entire string. Otherwise, it contains non-number
-  // characters and we can't parse it.
-  if (end < string->value + string->length) RETURN_NULL;
-
-  RETURN_NUM(number);
+  RETURN_VAL(number);
 }
 
 DEF_PRIMITIVE(num_pi)

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -720,7 +720,7 @@ DEF_PRIMITIVE(num_smallest)
 
 DEF_PRIMITIVE(num_toString)
 {
-  RETURN_VAL(wrenNumToString(vm, AS_NUM(args[0])));
+  RETURN_VAL(wrenNewStringFromDouble(vm, AS_NUM(args[0])));
 }
 
 DEF_PRIMITIVE(num_truncate)
@@ -852,10 +852,10 @@ DEF_PRIMITIVE(range_toString)
 {
   ObjRange* range = AS_RANGE(args[0]);
 
-  Value from = wrenNumToString(vm, range->from);
+  Value from = wrenNewStringFromDouble(vm, range->from);
   wrenPushRoot(vm, AS_OBJ(from));
 
-  Value to = wrenNumToString(vm, range->to);
+  Value to = wrenNewStringFromDouble(vm, range->to);
   wrenPushRoot(vm, AS_OBJ(to));
 
   Value result = wrenStringFormat(vm, "@$@", from,

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -1,4 +1,3 @@
-#include <ctype.h>
 #include <errno.h>
 #include <float.h>
 #include <math.h>
@@ -547,7 +546,7 @@ DEF_PRIMITIVE(num_fromString)
   double number = strtod(string->value, &end);
 
   // Skip past any trailing whitespace.
-  while (*end != '\0' && isspace((unsigned char)*end)) end++;
+  end = wrenEatSpace(end, NULL);
 
   if (errno == ERANGE) RETURN_ERROR("Number literal is too large.");
 

--- a/src/vm/wren_utils.h
+++ b/src/vm/wren_utils.h
@@ -93,6 +93,10 @@ int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
 int wrenSymbolTableFind(const SymbolTable* symbols,
                         const char* name, size_t length);
 
+// Skip past any whitespace.
+inline static
+char *wrenEatSpace(const char *s, size_t *length);
+
 // Returns the number of bytes needed to encode [value] in UTF-8.
 //
 // Returns 0 if [value] is too large to encode.
@@ -118,5 +122,22 @@ int wrenUtf8DecodeNumBytes(uint8_t byte);
 
 // Returns the smallest power of two that is equal to or greater than [n].
 int wrenPowerOf2Ceil(int n);
+
+#include <ctype.h>
+
+char *wrenEatSpace(const char *s, size_t *length)
+{
+  if (length == NULL)
+  {
+    while (*s != '\0' && isspace((unsigned char)*s)) s++;
+  } else {
+    while (*length > 0 && *s != '\0' && isspace((unsigned char)*s))
+    {
+      s++;
+      (*length)--;
+    }
+  }
+  return (char *)s;
+}
 
 #endif


### PR DESCRIPTION
My attempt at fixing issue #454. I try to inline functions with one call site, and try rationalize string to Num conversion. By doing so there is only one utility function used to convert numbers to strings, that is now shared in Num::fromString and the compiler. Note that it accepts scientific and hexadecimal values.

In extra, but commented, there are 2 extra *features*:
- Num::fromString would/should thow an error on invalid conversion, instead of returning null.
- wrenNewNumFromStringLength can be hardened to detect precision loss in hex format.