### PR TITLE
Add optional typing to the language.

### DIFF
--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -519,7 +519,7 @@ static bool findEntry(MapEntry* entries, uint32_t capacity, Value key,
 static bool insertEntry(MapEntry* entries, uint32_t capacity,
                         Value key, Value value)
 {
-  MapEntry* entry;
+  MapEntry* entry = NULL;
   if (findEntry(entries, capacity, key, &entry))
   {
     // Already present, so just replace the value.

--- a/test/language/optional_typing/methods_declarations.wren
+++ b/test/language/optional_typing/methods_declarations.wren
@@ -1,0 +1,23 @@
+
+class Foo {
+  static method(): Foo { Foo.new() }
+  static method(arg: Num): Foo { Foo.new() }
+  
+  construct new() { }
+  
+  method(): Foo { Foo.new() }
+  method(arg: Num): Foo { Foo.new() }
+  
+  [i : Num]: Foo { Foo.new() }
+  [i : Num] = (val: Num): Foo { Foo.new() }
+}
+
+System.print(Foo.method()) // expect: instance of Foo
+System.print(Foo.method(42)) // expect: instance of Foo
+
+var bar = Foo.new()
+System.print(bar.method()) // expect: instance of Foo
+System.print(bar.method(42)) // expect: instance of Foo
+
+System.print(bar[42]) // expect: instance of Foo
+System.print(bar[42] = 42) // expect: instance of Foo

--- a/test/language/optional_typing/variable_declarations.wren
+++ b/test/language/optional_typing/variable_declarations.wren
@@ -1,0 +1,6 @@
+
+var foo: Num
+System.print(foo) // expect: null
+
+var bar: Num = 42
+System.print(bar) // expect: 42


### PR DESCRIPTION
A WIP change to add optional typing to wren language.

Rationale: It might be interesting to be able to tag method arguments, their return value and variable definition with type definitions.

Short term: Be able to do weak type definition so user can document in code their types expectations, instead of relying on documentation or variable name tagging. It also helps reasoning when one expect a particular type or interface to be provided by the passed object, instead of needing to dig the code.

Long term: The compiler might evolve or an external compiler might emerge and use this to reason about the code generation.