### PR TITLE
Repaired amalgamation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,8 @@ gh-pages: docs
 	$(V) cp -r build/docs/. build/gh-pages
 
 # Build amalgamation of all Wren library files.
-amalgamation: src/include/wren.h src/vm/*.h src/vm/*.c
+amalgamation: src/include/wren.h src/vm/*.h src/vm/*.c src/optional/*.h src/vm/*.c
+	mkdir -p build
 	./util/generate_amalgamation.py > build/wren.c
 
 .PHONY: all amalgamation builtin clean debug docs gh-pages release test vm watchdocs ci ci_32 ci_64

--- a/util/generate_amalgamation.py
+++ b/util/generate_amalgamation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 from os.path import basename, dirname, join, realpath, isfile


### PR DESCRIPTION
I am not sure if anybody uses the amalgamation, but I love the idea of single file libraries. It makes it so easy to use the code in any project.

The amalgamation script now searches for files in the different directories of src.

Also the full paths in the amalgamation were replaced by the basename to produce the same content on all machines.

The makefile now creates the build directory for the amalgamation if it does not exist. I have added the ‘optional’ folder’s contents to the prerequisites, but the rule is phony anyway, so maybe they should be dropped completely.

I have not tried to run the test suite on the amalgamation, but at least it works with a simple test program. If you want, I can try to add support for amalgamation testing.