### PR TITLE
Stack protections

### DIFF
--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -72,6 +72,9 @@
 // Set this to true to print out the compiled bytecode of each function.
 #define WREN_DEBUG_DUMP_COMPILED_CODE 0
 
+// Set this to validate each stack manipulation
+#define WREN_DEBUG_STACK 0
+
 // Set this to trace each instruction as it's executed.
 #define WREN_DEBUG_TRACE_INSTRUCTIONS 0
 

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -519,7 +519,7 @@ static bool findEntry(MapEntry* entries, uint32_t capacity, Value key,
 static bool insertEntry(MapEntry* entries, uint32_t capacity,
                         Value key, Value value)
 {
-  MapEntry* entry;
+  MapEntry* entry = NULL;
   if (findEntry(entries, capacity, key, &entry))
   {
     // Already present, so just replace the value.


### PR DESCRIPTION
An attempt at solving issue #549. The approach is to validate `top` value against stack boundaries (trivial).
Since it requires the gcc expression statement expression it can't be enabled broadly. And since I only test it with gcc, I protected the test as I could.
