### PR TITLE
Add syntax sugar for maps

### DIFF
--- a/doc/site/maps.markdown
+++ b/doc/site/maps.markdown
@@ -134,3 +134,17 @@ that every entry will appear exactly once.
 
 <a class="right" href="method-calls.html">Method Calls &rarr;</a>
 <a href="lists.html">&larr; Lists</a>
+
+## Set
+
+You can create a set using a syntax sugar of map:
+
+    ::wren
+    var set1 = {1, 2, 3}
+    var set2 = {"foo", "bar": "baz"}
+
+is the same of:
+
+    ::wren
+    var set1 = {1: true, 2: true, 3: true}
+    var set2 = {"foo": true, "bar": "baz"}

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -2023,12 +2023,19 @@ static void map(Compiler* compiler, bool canAssign)
 
     // The key.
     parsePrecedence(compiler, PREC_UNARY);
-    consume(compiler, TOKEN_COLON, "Expect ':' after map key.");
-    ignoreNewlines(compiler);
 
     // The value.
-    expression(compiler);
-    callMethod(compiler, 2, "addCore_(_,_)", 13);
+    if (match(compiler, TOKEN_COLON)) {
+      ignoreNewlines(compiler);
+
+      expression(compiler);
+      callMethod(compiler, 2, "addCore_(_,_)", 13);
+    } else {
+      // Syntax sugar: if the colon isn't present, then emit a "true" value
+      // The map {1} is the same of {1: true}
+      emitOp(compiler, CODE_TRUE);
+      callMethod(compiler, 2, "addCore_(_,_)", 13);
+    }
   } while (match(compiler, TOKEN_COMMA));
 
   // Allow newlines before the closing '}'.

--- a/test/core/map/set.wren
+++ b/test/core/map/set.wren
@@ -1,0 +1,4 @@
+var a = {1: "foo", 2, 2}
+System.print(a[1])       // expect: foo
+System.print(a[2])       // expect: true
+System.print(a.count)    // expect: 2


### PR DESCRIPTION
Closes #137

This code

```
var set1 = {1, 2, 3}
var set2 = {"foo", "bar": "baz"}
```

now is the same of:

```
var set1 = {1: true, 2: true, 3: true}
var set2 = {"foo": true, "bar": "baz"}
```