### PR TITLE
Check that there is space in local variable array

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -2906,6 +2906,16 @@ static void forStatement(Compiler* compiler)
   // The space in the variable name ensures it won't collide with a user-defined
   // variable.
   expression(compiler);
+
+  // Verify that there is space to hidden local variables.
+  // Note that we expect only two addLocal calls next to each other in the
+  // following code.
+  if (compiler->numLocals + 2 > MAX_LOCALS)
+  {
+    error(compiler, "Cannot declare more than %d variables in one scope. (Not enough space for for-loops internal variables)",
+          MAX_LOCALS);
+    return;
+  }
   int seqSlot = addLocal(compiler, "seq ", 4);
 
   // Create another hidden local for the iterator object.

--- a/test/regression/561.wren
+++ b/test/regression/561.wren
@@ -1,0 +1,178 @@
+// This test caused an array oveflow in local variable array due to hidden
+// variables of for loop
+
+// expect error line 91
+var z = []
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+for (x in z) {
+
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}


### PR DESCRIPTION
Otherwise it can overflow due to for loop's hidden variables.

I was not sure should I try to patch addLocal function instead. Also I think the error message is too long, but I wanted to make it unique in case that somebody is trying to find where that error message came from. Also I couldn't figure out better way to do the regression test expectation.

Fix #561