### PR TITLE
Add multiple assignment

### DIFF
--- a/src/vm/wren_opcodes.h
+++ b/src/vm/wren_opcodes.h
@@ -203,6 +203,10 @@ OPCODE(IMPORT_MODULE, 1)
 // loaded variable onto the stack.
 OPCODE(IMPORT_VARIABLE, 1)
 
+// Unpack [arg1] first elements of a list [arg2].
+// If this list has less elements than [arg1], fill it with null.
+OPCODE(UNPACK_LIST, -2)
+
 // This pseudo-instruction indicates the end of the bytecode. It should
 // always be preceded by a `CODE_RETURN`, so is never actually executed.
 OPCODE(END, 0)

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1035,6 +1035,34 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
       PUSH(fn->module->variables.data[READ_SHORT()]);
       DISPATCH();
 
+    CASE_CODE(UNPACK_LIST):
+    {
+      int totalWished = (int) *(fiber->stackTop - 1);
+      Value* listPtr = (fiber->stackTop - 2);
+      ASSERT(IS_LIST(*listPtr), "Must unpack a list.");
+      ObjList* list = AS_LIST(*listPtr);
+
+      int elementsCount = list->elements.count;
+      Value elements[list->elements.count];
+      memcpy(elements, list->elements.data, sizeof(elements));
+
+      POP();
+      POP();
+
+      int count = (elementsCount > totalWished ? totalWished : elementsCount);
+      for (int i = 0; i < count; i++) {
+        PUSH(elements[i]);
+      }
+
+      if (totalWished > elementsCount) {
+        for (int i = 0; i < (totalWished - elementsCount); i++) {
+          PUSH(NULL_VAL);
+        }
+      }
+
+      DISPATCH();
+    }
+
     CASE_CODE(STORE_MODULE_VAR):
       fn->module->variables.data[READ_SHORT()] = PEEK();
       DISPATCH();

--- a/test/language/variable/multiple_assigment.wren
+++ b/test/language/variable/multiple_assigment.wren
@@ -1,0 +1,17 @@
+var a = [1, 2, 3]
+System.print(a) // expect: [1, 2, 3]
+
+var b, c = [1, "foo"]
+System.print(b) // expect: 1
+System.print(c) // expect: foo
+
+var d, e = ["bar", 2, 3]
+System.print(d) // expect: bar
+System.print(e) // expect: 2
+
+var f, g, h = [1, 2]
+System.print(f) // expect: 1
+System.print(g) // expect: 2
+System.print(h) // expect: null
+
+var i, j = 1 // expect assert failed: Must unpack a list.


### PR DESCRIPTION
Add support for write codes like

```
var a, b = [1, 2] // a is 1 and b is 2
```

It's more useful when you have a function with multiples returns, for examples

```
var string = "foo=1"
var key, value = string.split("=") // key is "foo" and value is "1"
```

I influenced myself with [Lua's assignments](https://www.lua.org/pil/4.1.html), then if you want unpack more values than the list length, the variables receives `null`:

```
var a, b, c = [1, 2] // a is 1, b is 2 and c is null
```

You also can unpack less values that the list length:

```
var a, b = [1, 2, 3] // a is 1, b is 2 and 3 is ignored
```

This new feature does not break compatibility, because the behaviour when you want assignment only one variable is the same:

```
var a = [1, 2, 3] // a is [1, 2, 3]
```

You only can do a multiple assignment with lists:

```
var a, b = 1 // raise an error
var a, b = "foo" // raise an error
```

Closes https://github.com/munificent/wren/issues/559