### PR TITLE
Renamed include guard in wren_compiler.h

### DIFF
--- a/src/vm/wren_compiler.h
+++ b/src/vm/wren_compiler.h
@@ -1,5 +1,5 @@
-#ifndef wren_parser_h
-#define wren_parser_h
+#ifndef wren_compiler_h
+#define wren_compiler_h
 
 #include "wren.h"
 #include "wren_value.h"


### PR DESCRIPTION
Renamed the include guard in wren_compiler.h from `wren_parser_h` to `wren_compiler_h`.