### PR TITLE
New C API functions: class retrieval, type checking and basic map support

### DIFF
--- a/src/cli/path.c
+++ b/src/cli/path.c
@@ -75,7 +75,7 @@ static size_t absolutePrefixLength(const char* path)
   // Drive letter.
   if (isDriveLetter(path[0]) && path[1] == ':')
   {
-    if (isSeparator(path->chars[2]))
+    if (isSeparator(path[2]))
     {
       // Fully absolute path.
       return 3;

--- a/src/module/io.c
+++ b/src/module/io.c
@@ -11,6 +11,10 @@
 #include <stdio.h>
 #include <fcntl.h>
 
+#ifndef O_SYNC
+#define O_SYNC 0 /* O_SYNC seem not to be defined in mingw32 */
+#endif
+
 typedef struct sFileRequestData
 {
   WrenHandle* fiber;

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -76,6 +76,7 @@
 #define IS_FOREIGN(value) (wrenIsObjType(value, OBJ_FOREIGN))   // ObjForeign
 #define IS_INSTANCE(value) (wrenIsObjType(value, OBJ_INSTANCE)) // ObjInstance
 #define IS_LIST(value) (wrenIsObjType(value, OBJ_LIST))         // ObjList
+#define IS_MAP(value) (wrenIsObjType(value, OBJ_MAP))         // ObjMap
 #define IS_RANGE(value) (wrenIsObjType(value, OBJ_RANGE))       // ObjRange
 #define IS_STRING(value) (wrenIsObjType(value, OBJ_STRING))     // ObjString
 
@@ -545,7 +546,7 @@ typedef struct
 #define SIGN_BIT ((uint64_t)1 << 63)
 
 // The bits that must be set to indicate a quiet NaN.
-#define QNAN ((uint64_t)0x7ffc000000000000)
+#define QNAN ((uint64_t)0x7ff8000000000000)
 
 // If the NaN bits are set, it's not a number.
 #define IS_NUM(value) (((value) & QNAN) != QNAN)

--- a/util/wren.mk
+++ b/util/wren.mk
@@ -56,7 +56,7 @@ ifeq ($(MODE),debug)
 	BUILD_DIR := $(BUILD_DIR)/debug
 else
 	WREN += wren
-	C_OPTIONS += -O3
+	C_OPTIONS += -s -O3
 	BUILD_DIR := $(BUILD_DIR)/release
 endif
 
@@ -93,10 +93,16 @@ OS := $(lastword $(subst -, ,$(shell gcc -dumpmachine)))
 # Don't add -fPIC on Windows since it generates a warning which gets promoted
 # to an error by -Werror.
 ifeq      ($(OS),mingw32)
-else ifeq ($(OS),cygwin)
-	# Do nothing.
 else
-	C_OPTIONS += -fPIC
+	ifeq ($(OS),cygwin)
+		# Do nothing.
+	else
+		ifeq ($(OS),)
+			# Do nothing.
+		else
+			C_OPTIONS += -fPIC
+		endif
+	endif
 endif
 
 # MinGW--or at least some versions of it--default CC to "cc" but then don't
@@ -117,7 +123,11 @@ else
 	ifeq ($(OS),mingw32)
 		LIBUV_LIBS := -lws2_32 -liphlpapi -lpsapi -luserenv
 	else
-		LIBUV_LIBS := -lpthread -lrt
+		ifeq ($(OS),)
+			LIBUV_LIBS := -lws2_32 -liphlpapi -lpsapi -luserenv
+		else
+			LIBUV_LIBS := -lpthread -lrt
+		endif
 	endif
 endif
 


### PR DESCRIPTION
This pull request adds the new following functions in the C API.

I think that these function are of a general use and they surprisingly appeared to be missing. So I propose to add them.

They are especially useful for foreign method implementors.
In the C/C++ side, type checking is an absolute must; not only basic types (Bool/Num/String), but also foreign types, to make sure the scripter calls a foreign method with an object of type X and not Y.
The more the API given to scripters is complex, the more it is important to type check all inputs.

## Added functions in the C API
### Class retrieval and comparison


- wrenGetSlotTypeName: get the type name of the object in slot, e.g. Num, Bool, String; useful for debugging or very simple type-checking
- wrenGetSlotClass: Retriev the class of an object into a slot
- wrenGetSlotIsClass, wrenGetSlotIsClassHandle: check if an object is an instance of a given class

### Type checking


- wrenCheckSlotBool: check if a vlue is a Bool
- wrenCheckSlotDouble: check if a value is a Num/double
- wrenCheckSlotString: check if a value is a string
- wrenCheckSlotList: check if a value is a list
- wrenCheckSlotMap: check if a value is a map
- wrenCheckSlotRange: check if a value is a range
- wrenCheckSlotForeign, wrenCheckSlotForeignHandle: check if a value is a foreign object of a given type

### Basic map support


- wrenSetSlotNewMap: store a new empty map
- wrenGetMapValue: retriev the value associated with a key in a map
- wrenPutInMap: associate a value with a key in a map
- wrenRemoveMap: Remove a key/value association from a map
- wrenClearMap: clear a map

### Range support


- wrenSetSlotNewRange: store a new range object
- wrenGetSlotRange: retriev the bounds and inclusivity of a range object

### miscellaneous functions


- wrenIsAborted: check if the current fiber has been aborted because of a runtime error or an explicit wrenAbortFiber call
