### PR TITLE
Remove unused prototype.

### DIFF
--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -137,10 +137,6 @@ void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign);
 // Creates a new [WrenHandle] for [value].
 WrenHandle* wrenMakeHandle(WrenVM* vm, Value value);
 
-// Executes [source] in the context of [module].
-WrenInterpretResult wrenInterpretInModule(WrenVM* vm, const char* module,
-                                          const char* source);
-
 // Compile [source] in the context of [module] and wrap in a fiber that can
 // execute it.
 //


### PR DESCRIPTION
`wrenInterpretInModule` has been replaced by `wrenInterpret`.