### PR TITLE
Update Call to `WrenInterpret` in Docs

### DIFF
--- a/doc/site/embedding/index.markdown
+++ b/doc/site/embedding/index.markdown
@@ -131,7 +131,9 @@ VM, waiting to run some code!
 You execute a string of Wren source code like so:
 
     :::c
-    WrenInterpretResult result = wrenInterpret(vm,
+    WrenInterpretResult result = wrenInterpret(
+        vm,
+        "my_module",
         "System.print(\"I am running in a VM!\")");
 
 The string is a series of one or more statements separated by newlines. Wren

--- a/doc/site/embedding/storing-c-data.markdown
+++ b/doc/site/embedding/storing-c-data.markdown
@@ -207,7 +207,7 @@ Over in the host, first we'll set up the VM:
       config.bindForeignMethodFn = bindForeignMethod;
 
       WrenVM* vm = wrenNewVM(&config);
-      wrenInterpret(vm, "some code...");
+      wrenInterpret(vm, "my_module", "some code...");
 
       return 0;
     }


### PR DESCRIPTION
Fixes #599 by updating the arguments to WrenInterpret to match the new
API.