### PR TITLE
Disable 32 bit macOS Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ ipch/
 *.user
 *.userosscache
 *.sln.docstates
+
+# macOS XCode build cache
+deps/libuv/build/XCBuildData/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
   - clang
 env:
-  - WREN_OPTIONS="" CI_ARCHS="ci_32 ci_64"
+  - WREN_OPTIONS="" CI_ARCHS="ci_64"
   - WREN_OPTIONS="-DWREN_NAN_TAGGING=0" CI_ARCHS="ci_64"
 
 # Automatically build and deploy docs.

--- a/util/build_libuv.py
+++ b/util/build_libuv.py
@@ -26,7 +26,7 @@ def build_libuv_mac():
   run([
     "xcodebuild",
     # Build a 32-bit + 64-bit universal binary:
-    "ARCHS=i386 x86_64", "ONLY_ACTIVE_ARCH=NO",
+    "ARCHS=x86_64", "ONLY_ACTIVE_ARCH=NO",
     "BUILD_DIR=out",
     "-project", LIB_UV_DIR + "/uv.xcodeproj",
     "-configuration", "Release",


### PR DESCRIPTION
With the latest XCode it looks like 32 bit builds are deprecated. This
causes build warnings which fail the libuv build. This commit removes
the 32 bit arch from the macOS libuv build, and stops building the 32
build on Travis.