### PR TITLE
Fix format overflow error, use snprintf/vsnprintf

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -399,8 +399,8 @@ static void printError(Parser* parser, int line, const char* label,
   
   // Format the label and message.
   char message[ERROR_MESSAGE_SIZE];
-  int length = sprintf(message, "%s: ", label);
-  length += vsprintf(message + length, format, args);
+  int length = snprintf(message, ERROR_MESSAGE_SIZE, "%s: ", label);
+  length += vsnprintf(message + length, ERROR_MESSAGE_SIZE, format, args);
   ASSERT(length < ERROR_MESSAGE_SIZE, "Error should not exceed buffer.");
   
   parser->vm->config.errorFn(parser->vm, WREN_ERROR_COMPILE,
@@ -449,11 +449,11 @@ static void error(Compiler* compiler, const char* format, ...)
     char label[ERROR_MESSAGE_SIZE];
     if (token->length <= MAX_VARIABLE_NAME)
     {
-      sprintf(label, "Error at '%.*s'", token->length, token->start);
+      snprintf(label, ERROR_MESSAGE_SIZE, "Error at '%.*s'", token->length, token->start);
     }
     else
     {
-      sprintf(label, "Error at '%.*s...'", MAX_VARIABLE_NAME, token->start);
+      snprintf(label, ERROR_MESSAGE_SIZE, "Error at '%.*s...'", MAX_VARIABLE_NAME, token->start);
     }
     printError(compiler->parser, token->line, label, format, args);
   }

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -784,7 +784,7 @@ Value wrenNumToString(WrenVM* vm, double value)
   // + 1 char for "\0"
   // = 24
   char buffer[24];
-  int length = sprintf(buffer, "%.14g", value);
+  int length = snprintf(buffer, sizeof(buffer), "%.14g", value);
   return wrenNewStringLength(vm, buffer, length);
 }
 


### PR DESCRIPTION
I'm on a system with a rather recent GCC (8.2.1) which enables `-Werror=format-overflow` by default. In combination with `-Werror` this makes the build fail for me:

```
src/vm/wren_compiler.c: In function ‘error’:                                       
src/vm/wren_compiler.c:402:36: error: ‘: ’ directive writing 2 bytes into a region o
f size between 1 and 159 [-Werror=format-overflow=]                                
   int length = sprintf(message, "%s: ", label);                                   
                                    ^~                                             
src/vm/wren_compiler.c:402:16: note: ‘sprintf’ output between 3 and 161 bytes into a
 destination of size 159                                                           
   int length = sprintf(message, "%s: ", label);                                   
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                    
cc1: all warnings being treated as errors
make[1]: *** [util/wren.mk:223: build/release/vm/wren_compiler.o] Error 1
make[1]: Leaving directory '/home/wasa/code/forks/wren'
make: *** [Makefile:16: release] Error 2
```

To fix this I've replaced the `sprintf` call with `snprintf` (and `vsprintf` with `vsnprintf`) and used the actual buffer length for the second argument, this ensures that no overflow can happen. While I was at it, I fixed another use of `sprintf`.

Please let me know if this isn't acceptable (like, because you won't have `snprintf` on Windows) and disabling the warning is the way to go.