### PR TITLE
Fixup Handling of `\` in REPL to Prevent Crash

### DIFF
--- a/src/module/repl.wren
+++ b/src/module/repl.wren
@@ -828,7 +828,7 @@ class Lexer {
 
       if (c == Chars.backslash) {
         // TODO: Process specific escapes and validate them.
-        advance()
+        if (!isAtEnd) advance()
       } else if (c == Chars.percent) {
         // Consume the '('.
         if (!isAtEnd) advance()

--- a/src/module/repl.wren.inc
+++ b/src/module/repl.wren.inc
@@ -830,7 +830,7 @@ static const char* replModuleSource =
 "\n"
 "      if (c == Chars.backslash) {\n"
 "        // TODO: Process specific escapes and validate them.\n"
-"        advance()\n"
+"        if (!isAtEnd) advance()\n"
 "      } else if (c == Chars.percent) {\n"
 "        // Consume the '('.\n"
 "        if (!isAtEnd) advance()\n"


### PR DESCRIPTION
When parsing the string token if a `\` was used it would
unconditionally consume the next character. This would led to a token
with an invalid lenght causing a crash when it was printed. This fixes
that by only consuming the token after the `\` if there is one to
consume.

Fixes #603