### PR TITLE
Fix doc generation script

### DIFF
--- a/util/generate_docs.py
+++ b/util/generate_docs.py
@@ -126,7 +126,7 @@ def format_file(path, skip_up_to_date):
           # visible.
           contents += line
 
-  html = markdown.markdown(contents, ['def_list', 'codehilite', 'smarty'])
+  html = markdown.markdown(contents, extensions=['def_list', 'codehilite', 'smarty'])
 
   # Use special formatting for example output and errors.
   html = html.replace('<span class="c1">//&gt; ', '<span class="output">')


### PR DESCRIPTION
`make docs` was failing for me due to to line 129 of `util/generate_docs.py`:
```python
html = markdown.markdown(contents, ['def_list', 'codehilite', 'smarty'])
```
The only markdown modules I could find had `markdown.markdown` taking two arguments: `text`, and `**kwargs`. The required kwarg in this was `extensions=`.