### PR TITLE
Fix overflow on line 401 of wren_compiler.c

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -446,7 +446,7 @@ static void error(Compiler* compiler, const char* format, ...)
   else
   {
     // Make sure we don't exceed the buffer with a very long token.
-    char label[ERROR_MESSAGE_SIZE];
+    char label[10 + MAX_VARIABLE_NAME + 4 + 1];
     if (token->length <= MAX_VARIABLE_NAME)
     {
       sprintf(label, "Error at '%.*s'", token->length, token->start);


### PR DESCRIPTION
Line 401 of wren_compiler.c allocates space for `ERROR_MESSAGE_SIZE`, but line 402 has `int length = sprintf(message, "%s: ", label);`, which overflows `message` by two characters.

#614 tried to fix this, but I looked through the commit and it doesn't look like it solved the problem, and nobody's touched the PR for almost a month now, so I thought I'd send this one.