### PR TITLE
Fix a bunch of thread value and call frames stack errors.

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -988,6 +988,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
         RUNTIME_ERROR();
       }
 
+      STORE_FRAME();
       switch (method->type)
       {
         case METHOD_PRIMITIVE:
@@ -998,7 +999,6 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
             fiber->stackTop -= numArgs - 1;
           } else {
             // An error, fiber switch, or call frame change occurred.
-            STORE_FRAME();
 
             // If we don't have a fiber to switch to, stop interpreting.
             fiber = vm->fiber;
@@ -1011,10 +1011,10 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
         case METHOD_FOREIGN:
           callForeign(vm, fiber, method->as.foreign, numArgs);
           if (!IS_NULL(fiber->error)) RUNTIME_ERROR();
+          LOAD_FRAME();
           break;
 
         case METHOD_BLOCK:
-          STORE_FRAME();
           wrenCallFunction(vm, fiber, (ObjClosure*)method->as.closure, numArgs);
           LOAD_FRAME();
           break;


### PR DESCRIPTION
The issues are related to the fact that when calling a primitive of a
foreign, the frame need to be stored before invoking such
foreign/primitives, and not be used directly after invoking them.

The rationale is pretty simple: despite all the efforts, there is no
garantee that any function might not corrupt some cached values.

In the case of a primitive, there the function is at fault here, since
we get the fallowing stack call:
 runInterpreter() -- Has a cache of current frame pointer
 ->prim_fn_call*()
   ->wrenCallFunction()
     ->wrenAppendCallFrame() -- Might grow the frame stack.
Therefore calling STORE_FRAME after the primitive call in
runInterpreter is bogus, since current call frame is possibly dandling
after wrenAppendCallFrame, even if it does correctly report a need to
reload the frame.

In the case of foreign, it is as simple:
  runInterpreter() -- Has a cache of various stack frame pointers
  ->any foreign()
    ->wrenEnsureSlots() -- Might grow the stack.
Since any foreign might call wrenEnsureSlots, there is a chance that the
cached values are also invalid after a wrenEnsureSlot.

It does result in an unbanlanced [STORE/LOAD]_FRAME for performance
reasons. While the LOAD_FRAME could have been moved after the switch,
the switch, generalising the case, it has a huge impact on primitive
performance. Therefore the primitive case should still be left without a
LOAD_FRAME in case it returns true.