### PR TITLE
Fix broken link for error handling

### DIFF
--- a/doc/site/embedding/index.markdown
+++ b/doc/site/embedding/index.markdown
@@ -151,7 +151,7 @@ fibers all the way back to the main one and returns `WREN_RESULT_RUNTIME_ERROR`.
 Otherwise, when the last fiber successfully returns, it returns
 `WREN_RESULT_SUCCESS`.
 
-[runtime error]: error-handling.html
+[runtime error]: ../error-handling.html
 
 All code passed to `wrenInterpret()` runs in a special "main" module. That way,
 top-level names defined in one call can be accessed in later ones. It's similar


### PR DESCRIPTION
The "runtime error" link on `http://wren.io/embedding/` was broken, so I updated it to point to `http://wren.io/error-handling.html`. I checked all the other links in the Embedding guide to make sure they work too.