### PR TITLE
Adding foreign constructor test case, passing a list as argument.

### DIFF
--- a/test/api/foreign_constructor.c
+++ b/test/api/foreign_constructor.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "foreign_constructor.h"
+
+static void adderAllocate(WrenVM* vm)
+{
+  double* total = (double*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(double));
+
+  int count = wrenGetListCount(vm, 1);
+
+  int slots = wrenGetSlotCount(vm);
+  const int aux_slot_id = slots;
+  wrenEnsureSlots(vm, aux_slot_id + 1);
+
+  *total = 0;
+  for (int i = 0; i < count; ++i) {
+      wrenGetListElement(vm, 1, i, aux_slot_id);
+
+      *total += wrenGetSlotDouble(vm, aux_slot_id);
+  }
+}
+
+static void adderTotal(WrenVM* vm)
+{
+  double total = *(double*)wrenGetSlotForeign(vm, 0);
+  wrenSetSlotDouble(vm, 0, total);
+}
+
+WrenForeignMethodFn foreignConstructorBindMethod(const char* signature)
+{
+  if (strcmp(signature, "Adder.total") == 0) return adderTotal;
+
+  return NULL;
+}
+
+void foreignConstructorBindClass(
+    const char* className, WrenForeignClassMethods* methods)
+{
+  if (strcmp(className, "Adder") == 0)
+  {
+    methods->allocate = adderAllocate;
+    return;
+  }
+}

--- a/test/api/foreign_constructor.h
+++ b/test/api/foreign_constructor.h
@@ -1,0 +1,5 @@
+#include "wren.h"
+
+WrenForeignMethodFn foreignConstructorBindMethod(const char* signature);
+void foreignConstructorBindClass(
+    const char* className, WrenForeignClassMethods* methods);

--- a/test/api/foreign_constructor.wren
+++ b/test/api/foreign_constructor.wren
@@ -1,0 +1,8 @@
+// Class with a special constructor.
+foreign class Adder {
+  construct new(values) {}
+  foreign total
+}
+
+var adder = Adder.new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+System.print(adder.total) // expect: 45

--- a/test/api/main.c
+++ b/test/api/main.c
@@ -11,6 +11,7 @@
 #include "error.h"
 #include "get_variable.h"
 #include "foreign_class.h"
+#include "foreign_constructor.h"
 #include "handle.h"
 #include "lists.h"
 #include "new_vm.h"
@@ -55,6 +56,9 @@ static WrenForeignMethodFn bindForeignMethod(
   method = foreignClassBindMethod(fullName);
   if (method != NULL) return method;
   
+  method = foreignConstructorBindMethod(fullName);
+  if (method != NULL) return method;
+  
   method = handleBindMethod(fullName);
   if (method != NULL) return method;
 
@@ -86,6 +90,9 @@ static WrenForeignClassMethods bindForeignClass(
   if (strncmp(module, "./test/", 7) != 0) return methods;
 
   foreignClassBindClass(className, &methods);
+  if (methods.allocate != NULL) return methods;
+  
+  foreignConstructorBindClass(className, &methods);
   if (methods.allocate != NULL) return methods;
   
   resetStackAfterForeignConstructBindClass(className, &methods);


### PR DESCRIPTION
I've added this simple test case, showing that passing a list as an argument to a foreign constructor fails.

It seems like requesting a new slot from within the constructor, in order to process the list content, messes the stack pointer up.