### PR TITLE
Add tests for stack corruption (#641)

### DIFF
--- a/test/api/call_calls_foreign.wren
+++ b/test/api/call_calls_foreign.wren
@@ -1,9 +1,10 @@
-// Regression test for https://github.com/munificent/wren/issues/510.
-//
-// Tests that re-entrant API calls are handled correctly. The host uses
-// `wrenCall()` to invoke `CallCallsForeign.call()`. That in turn calls
-// `CallCallsForeign.api()`, which goes back through the API.
 class CallCallsForeign {
+  // Regression test for https://github.com/munificent/wren/issues/510.
+  //
+  // Tests that re-entrant API calls are handled correctly. The host uses
+  // `wrenCall()` to invoke `CallCallsForeign.call()`. That in turn calls
+  // `CallCallsForeign.api()`, which goes back through the API.
+
   foreign static api()
 
   static call(param) {
@@ -13,5 +14,14 @@ class CallCallsForeign {
     System.print(param) // expect: parameter
     // expect: slots after 1
     return "result"
+  }
+
+  // Tests that foreign functions do not corrupt the stack.
+
+  foreign static api2()
+
+  static call2() {
+    return api2()
+    // expect: return type 1
   }
 }

--- a/test/language/function/recurse_stack.wren
+++ b/test/language/function/recurse_stack.wren
@@ -1,0 +1,9 @@
+var count = 0
+var f
+
+f = Fn.new {|n|
+  if (n == 0) count = count + 1 else f.call(n - 1) 
+}
+
+f.call(10)
+System.print(count) // expect: 1


### PR DESCRIPTION
This PR adds tests for stack errors that got fixed in #641. Both tests fail with current master (a8fd838) and pass with #641 applied.

Details:
- The test for primitive calls outputs approximately log_2(n) since the call stack is reallocated this many times.
- The bug for the foreign call case is triggered by an incorrect memory write with a foreign `CALL_0` instruction followed by `RETURN`.

Please point out if anything needs to be improved or corrected. Thanks!