### PR TITLE
Fix horrendously bad bit hashing function.

### DIFF
--- a/test/benchmark/map_numeric.dart.skip
+++ b/test/benchmark/map_numeric.dart.skip
@@ -6,17 +6,17 @@ main() {
 
   var map = {};
 
-  for (var i = 1; i <= 1000000; i++) {
+  for (var i = 1; i <= 2000000; i++) {
     map[i] = i;
   }
 
   var sum = 0;
-  for (var i = 1; i <= 1000000; i++) {
+  for (var i = 1; i <= 2000000; i++) {
     sum += map[i];
   }
   print(sum);
 
-  for (var i = 1; i <= 1000000; i++) {
+  for (var i = 1; i <= 2000000; i++) {
     map.remove(i);
   }
 

--- a/test/benchmark/map_numeric.lua
+++ b/test/benchmark/map_numeric.lua
@@ -2,17 +2,17 @@ local start = os.clock()
 
 local map = {}
 
-for i = 1, 1000000 do
+for i = 1, 2000000 do
   map[i] = i
 end
 
 local sum = 0
-for i = 1, 1000000 do
+for i = 1, 2000000 do
   sum = sum + map[i]
 end
 io.write(string.format("%d\n", sum))
 
-for i = 1, 1000000 do
+for i = 1, 2000000 do
   map[i] = nil
 end
 

--- a/test/benchmark/map_numeric.py
+++ b/test/benchmark/map_numeric.py
@@ -6,15 +6,15 @@ start = time.clock()
 
 map = {}
 
-for i in range(1, 1000001):
+for i in range(1, 2000001):
   map[i] = i
 
 sum = 0
-for i in range(1, 1000001):
+for i in range(1, 2000001):
   sum = sum + map[i]
 print(sum)
 
-for i in range(1, 1000001):
+for i in range(1, 2000001):
   del map[i]
 
 print("elapsed: " + str(time.clock() - start))

--- a/test/benchmark/map_numeric.rb
+++ b/test/benchmark/map_numeric.rb
@@ -2,17 +2,17 @@ start = Time.now
 
 map = Hash.new
 
-for i in (1..1000000)
+for i in (1..2000000)
   map[i] = i
 end
 
 sum = 0
-for i in (1..1000000)
+for i in (1..2000000)
   sum = sum + map[i]
 end
 puts sum
 
-for i in (1..1000000)
+for i in (1..2000000)
   map.delete(i)
 end
 

--- a/test/benchmark/map_numeric.wren
+++ b/test/benchmark/map_numeric.wren
@@ -2,17 +2,17 @@ var start = System.clock
 
 var map = {}
 
-for (i in 1..1000000) {
+for (i in 1..2000000) {
   map[i] = i
 }
 
 var sum = 0
-for (i in 1..1000000) {
+for (i in 1..2000000) {
   sum = sum + map[i]
 }
 System.print(sum)
 
-for (i in 1..1000000) {
+for (i in 1..2000000) {
   map.remove(i)
 }
 

--- a/util/benchmark.py
+++ b/util/benchmark.py
@@ -86,7 +86,7 @@ BENCHMARK("for", r"""499999500000""")
 BENCHMARK("method_call", r"""true
 false""")
 
-BENCHMARK("map_numeric", r"""500000500000""")
+BENCHMARK("map_numeric", r"""2000001000000""")
 
 BENCHMARK("map_string", r"""12799920000""")
 


### PR DESCRIPTION
I was writing a little test script that coincidentally built a map containing a few million integers keys when I discovered the performance tanked. It's from the hash function. hashBits() is used to generate a hash code from the same 64 bits used to represent a Wren number as a double. When building a map containing a large number of integer keys, it's important for this to do a good job scattering the bits across the 32-bit key space.

Alas, it does not. Worse, the benchmark to test this happens to stop just before the performance falls off a cliff, so this was easy to overlook. I updated the map_numeric benchmark to use larger maps to catch this. I can't show before/after numbers because at the larger size, the old version is too slow to finish running. I gave it a few minutes, but it still hadn't completed a single round. Instead, I used this little test script:

```
for (j in 0..10) {
  var map = {}
  var size = 1000000 + j * 100000

  var start = System.clock
  for (i in 1..size) {
    map[i] = i
  }

  var elapsed = System.clock - start
  System.print("size %(size), time %(elapsed)")
}
```

With the previous code, on my Mac laptop this outputs:

```
size 1000000, time 0.141727
size 1100000, time 3.649353
size 1200000, time 23.404542
size 1300000, time 81.003917
size 1400000, time 100.350219
```

Then I gave up and aborted it. The time here should only slightly increase about 10% each step since the maps get 10% bigger each time. Instead, by the time it's 40% larger, the time is almost 1000 *times* slower. Oops.

With this PR, the results are:

```
size 1000000, time 0.189849
size 1100000, time 0.220847
size 1200000, time 0.230764
size 1300000, time 0.244137
size 1400000, time 0.271335
size 1500000, time 0.288265
size 1600000, time 0.378582
size 1700000, time 0.379689
size 1800000, time 0.383916
size 1900000, time 0.399345
size 2000000, time 0.412544
```

Which is exactly what you'd expect. I wanted to understand *why* it was so bad, so I wrote some diagnostic code to get a picture, literally, of what's going on. [This gist](https://gist.github.com/munificent/b4a733baab60ecb3a3cbd275f6e27446) renders a PPM image of a given map showing what's in each bucket.

With the current hash function, on one of example maps above, you get:

![before](https://user-images.githubusercontent.com/46275/61999353-f0d92100-b073-11e9-8d0c-c54e3e4204aa.png)

That's like, *really* bad. All of the entries are clustered into one small region. Those brighter colors inside entries that are far away from their ideal bucket, which means there is a mountain of collisions occurring. Millions of entries are fighting for the same few buckets and spilling over.

Here is what you get after applying this PR:

![after](https://user-images.githubusercontent.com/46275/61999354-f33b7b00-b073-11e9-8931-fdf838accd2b.png)

This is basically an ideal image: a pattern-less noise of empty cells and cells containing keys right where they want to be or very close to it.