### PR TITLE
Fix wrenAbortFiber does not work inside of foreign class allocator

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1198,6 +1198,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
     CASE_CODE(FOREIGN_CONSTRUCT):
       ASSERT(IS_CLASS(stackStart[0]), "'this' should be a class.");
       createForeign(vm, fiber, stackStart);
+      if (wrenHasError(fiber)) RUNTIME_ERROR();
       DISPATCH();
 
     CASE_CODE(CLOSURE):

--- a/test/api/foreign_class.c
+++ b/test/api/foreign_class.c
@@ -82,6 +82,13 @@ static void resourceFinalize(void* data)
   finalized++;
 }
 
+static void badClassAllocate(WrenVM* vm)
+{
+  wrenEnsureSlots(vm, 1);
+  wrenSetSlotString(vm, 0, "Something went wrong");
+  wrenAbortFiber(vm, 0);
+}
+
 WrenForeignMethodFn foreignClassBindMethod(const char* signature)
 {
   if (strcmp(signature, "static ForeignClass.finalized") == 0) return apiFinalized;
@@ -112,6 +119,12 @@ void foreignClassBindClass(
   {
     methods->allocate = resourceAllocate;
     methods->finalize = resourceFinalize;
+    return;
+  }
+
+  if (strcmp(className, "BadClass") == 0)
+  {
+    methods->allocate = badClassAllocate;
     return;
   }
 }

--- a/test/api/foreign_class.wren
+++ b/test/api/foreign_class.wren
@@ -75,3 +75,13 @@ resources.clear()
 
 System.gc()
 System.print(ForeignClass.finalized) // expect: 3
+
+// Class that aborts fiber
+foreign class BadClass {
+  construct new() {}
+}
+
+error = Fiber.new {
+  BadClass.new()
+}.try()
+System.print(error) // expect: Something went wrong


### PR DESCRIPTION
This fixes issue #697

### Description

Consider a foreign class that has to abort a fiber in the constructor. An example of this would be a C++ class that throws an exception in its constructor. To do that, one must call `wrenAbortFiber` inside of the allocator function, but at the moment Wren ignores the error. This pull request fixes that problem. More information in issue issue #697 

Quick example:

```
foreign class BadClass {
  construct new() {}
}

error = Fiber.new {
  BadClass.new()
}.try()
System.print(error) // expect: Something went wrong
```

Without this change, the above `System.print` would output: `String does not implement 'init new()'` (because it thinks the fiber error message is the class instance!)

### Changes

* A single change in `src/vm/wren_vm.c` that adds a check if an error has been raised. 
* Added API test for this change.