### PR TITLE
Fix #710 – Calling wrenEnsureSlots before wrenInterpret causes apiStack to become invalid

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1447,7 +1447,9 @@ WrenInterpretResult wrenInterpret(WrenVM* vm, const char* module,
   ObjFiber* fiber = wrenNewFiber(vm, closure);
   wrenPopRoot(vm); // closure.
   
-  return runInterpreter(vm, fiber);
+  WrenInterpretResult result = runInterpreter(vm, fiber);
+  vm->fiber = fiber;
+  return result;
 }
 
 ObjClosure* wrenCompileSource(WrenVM* vm, const char* module, const char* source,


### PR DESCRIPTION
This PR fixes #710. 

I am not sure if this causes memory leaks or not. As far as I know, the fiber should somehow be freed, but I can't tell how. Valgrind does report some problems, but they seem unrelated to this issue.

This does not include any tests, because I have no idea how the test system works. If anyone can explain it to me, I'd be more than happy to create a test for this.