### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/util/vs2017/README.md
+++ b/util/vs2017/README.md
@@ -1,3 +1,14 @@
 # Building on windows
 
 Building the `wren` project requires python2 to available in the path as `python`, in order to download and build the libuv dependency. The download and build of libuv is done as a pre-build step by the solution.
+
+You can download and install `wren` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ vcpkg install wren
+
+The `wren` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+


### PR DESCRIPTION
`Wren `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `wren `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `wren`, ready to be included in their projects.

We also test whether our library ports build in various configurations (currently only support static) configurations on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/wren/portfile.cmake). We try to keep the library maintained as close as possible to the original library.