### PR TITLE
wren: Remove a magic number in the compiler.

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -2088,7 +2088,7 @@ static void field(Compiler* compiler, bool canAssign)
 {
   // Initialize it with a fake value so we can keep parsing and minimize the
   // number of cascaded errors.
-  int field = 255;
+  int field = MAX_FIELDS;
 
   ClassInfo* enclosingClass = getEnclosingClass(compiler);
 


### PR DESCRIPTION
Hi,
Remove a magic number in field function, the 255 is meant to be MAX_FIELDS so that it doesn't produce code and enforce an error.
Cheers