### PR TITLE
Small tweaks to error handling.

### DIFF
--- a/src/vm/wren_primitive.c
+++ b/src/vm/wren_primitive.c
@@ -23,9 +23,7 @@ static uint32_t validateIndexValue(WrenVM* vm, uint32_t count, double value,
 bool validateFn(WrenVM* vm, Value arg, const char* argName)
 {
   if (IS_CLOSURE(arg)) return true;
-
-  vm->fiber->error = wrenStringFormat(vm, "$ must be a function.", argName);
-  return false;
+  RETURN_ERROR_FMT("$ must be a function.", argName);
 }
 
 bool validateNum(WrenVM* vm, Value arg, const char* argName)

--- a/src/vm/wren_primitive.h
+++ b/src/vm/wren_primitive.h
@@ -43,10 +43,10 @@
       return false;                                                            \
     } while (false)
 
-#define RETURN_ERROR_FMT(msg, arg)                                             \
+#define RETURN_ERROR_FMT(...)                                                  \
     do                                                                         \
     {                                                                          \
-      vm->fiber->error = wrenStringFormat(vm, msg, arg);                       \
+      vm->fiber->error = wrenStringFormat(vm, __VA_ARGS__);                    \
       return false;                                                            \
     } while (false)
 

--- a/src/vm/wren_primitive.h
+++ b/src/vm/wren_primitive.h
@@ -53,7 +53,6 @@
 // Validates that the given [arg] is a function. Returns true if it is. If not,
 // reports an error and returns false.
 bool validateFn(WrenVM* vm, Value arg, const char* argName);
-bool validateFn(WrenVM* vm, Value arg, const char* argName);
 
 // Validates that the given [arg] is a Num. Returns true if it is. If not,
 // reports an error and returns false.

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1753,8 +1753,7 @@ void wrenGetVariable(WrenVM* vm, const char* module, const char* name,
 {
   ASSERT(module != NULL, "Module cannot be NULL.");
   ASSERT(name != NULL, "Variable name cannot be NULL.");  
-  validateApiSlot(vm, slot);
-  
+
   Value moduleName = wrenStringFormat(vm, "$", module);
   wrenPushRoot(vm, AS_OBJ(moduleName));
   


### PR DESCRIPTION
Hi,
The following changes allow RETURN_ERROR_FMT to take any number of arguments and not just one, and make use of the macro in a missed place.
Also removes a validateApiSlot call in wrenGetVariable. The function already check the slot index later because of the setSlot call. These kind of changes degrade a little the stack traces on debugging, but since these functions are pretty trivial, I don't think it is trivial to bloat them with duplicated checks.
Cheers,
   Michel