### PR TITLE
Revert "Fix slot array corrupted by wrenInterpret()"

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1446,12 +1446,8 @@ WrenInterpretResult wrenInterpret(WrenVM* vm, const char* module,
   wrenPushRoot(vm, (Obj*)closure);
   ObjFiber* fiber = wrenNewFiber(vm, closure);
   wrenPopRoot(vm); // closure.
-
-  WrenInterpretResult result = runInterpreter(vm, fiber);
-
-  vm->fiber = NULL;
-  vm->apiStack = NULL;
-  return result;
+  
+  return runInterpreter(vm, fiber);
 }
 
 ObjClosure* wrenCompileSource(WrenVM* vm, const char* module, const char* source,

--- a/test/api/new_vm.c
+++ b/test/api/new_vm.c
@@ -13,43 +13,9 @@ static void nullConfig(WrenVM* vm)
   wrenFreeVM(otherVM);
 }
 
-static void multipleInterpretCalls(WrenVM* vm)
-{
-  WrenVM* otherVM = wrenNewVM(NULL);
-  WrenInterpretResult result;
-
-  bool correct = true;
-
-  // Handles should be valid across calls into Wren code.
-  WrenHandle* absMethod = wrenMakeCallHandle(otherVM, "abs");
-
-  for (int i = 0; i < 5; i++) {
-    // Calling `wrenEnsureSlots()` before `wrenInterpret()` should not introduce
-    // problems later.
-    wrenEnsureSlots(otherVM, 2);
-
-    result = wrenInterpret(otherVM, "main", "1 + 2");
-    correct = correct && (result == WREN_RESULT_SUCCESS);
-
-    wrenEnsureSlots(otherVM, 2);
-    wrenSetSlotDouble(otherVM, 0, -i);
-    result = wrenCall(otherVM, absMethod);
-    correct = correct && (result == WREN_RESULT_SUCCESS);
-
-    double absValue = wrenGetSlotDouble(otherVM, 0);
-    correct = correct && (absValue == (double)i);
-  }
-
-  wrenSetSlotBool(vm, 0, correct);
-
-  wrenReleaseHandle(otherVM, absMethod);
-  wrenFreeVM(otherVM);
-}
-
 WrenForeignMethodFn newVMBindMethod(const char* signature)
 {
   if (strcmp(signature, "static VM.nullConfig()") == 0) return nullConfig;
-  if (strcmp(signature, "static VM.multipleInterpretCalls()") == 0) return multipleInterpretCalls;
 
   return NULL;
 }

--- a/test/api/new_vm.wren
+++ b/test/api/new_vm.wren
@@ -1,8 +1,6 @@
 class VM {
   foreign static nullConfig()
-  foreign static multipleInterpretCalls()
 }
 // TODO: Other configuration settings.
 
 System.print(VM.nullConfig()) // expect: true
-System.print(VM.multipleInterpretCalls()) // expect: true


### PR DESCRIPTION
Reverts wren-lang/wren#730
Hi,
After further analysis, this change does not really fix the root cause of the problem.
In addition, it forbids the access of results of the invocation of wrenInterpret.

The issue could also be solved by applying:
```
diff --git a/src/vm/wren_vm.c b/src/vm/wren_vm.c
index e8dad4ab..bc30cdfe 100644
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1447,11 +1447,7 @@ WrenInterpretResult wrenInterpret(WrenVM* vm, const char* module,
   ObjFiber* fiber = wrenNewFiber(vm, closure);
   wrenPopRoot(vm); // closure.
 
-  WrenInterpretResult result = runInterpreter(vm, fiber);
-
-  vm->fiber = NULL;
-  vm->apiStack = NULL;
-  return result;
+  return runInterpreter(vm, fiber);
 }
 
 ObjClosure* wrenCompileSource(WrenVM* vm, const char* module, const char* source,
@@ -1565,7 +1561,7 @@ int wrenGetSlotCount(WrenVM* vm)
 void wrenEnsureSlots(WrenVM* vm, int numSlots)
 {
   // If we don't have a fiber accessible, create one for the API to use.
-  if (vm->apiStack == NULL)
+  if ((vm->fiber != NULL && vm->fiber->numFrames == 0) || vm->apiStack == NULL)
   {
     vm->fiber = wrenNewFiber(vm, NULL);
     vm->apiStack = vm->fiber->stack;
```
which has the advantage of not resetting the fibers (which would allow to get the result of wrenInterpret, but needs to be tested/fixed), but has another issue that force the recreation of fiber when invoked from C, leading to horrible performance in the benchmarks.
