### PR TITLE
wren/vm: Allow wrenInterpret to call foreign function (complement 344d343 at fixing #730).

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1447,12 +1447,9 @@ WrenInterpretResult wrenInterpret(WrenVM* vm, const char* module,
   wrenPushRoot(vm, (Obj*)closure);
   ObjFiber* fiber = wrenNewFiber(vm, closure);
   wrenPopRoot(vm); // closure.
-
-  WrenInterpretResult result = runInterpreter(vm, fiber);
-
-  vm->fiber = NULL;
   vm->apiStack = NULL;
-  return result;
+
+  return runInterpreter(vm, fiber);
 }
 
 ObjClosure* wrenCompileSource(WrenVM* vm, const char* module, const char* source,

--- a/test/api/new_vm.c
+++ b/test/api/new_vm.c
@@ -23,12 +23,16 @@ static void multipleInterpretCalls(WrenVM* vm)
   // Handles should be valid across calls into Wren code.
   WrenHandle* absMethod = wrenMakeCallHandle(otherVM, "abs");
 
+  result = wrenInterpret(otherVM, "main", "import \"random\" for Random");
+  correct = correct && (result == WREN_RESULT_SUCCESS);
+
   for (int i = 0; i < 5; i++) {
     // Calling `wrenEnsureSlots()` before `wrenInterpret()` should not introduce
     // problems later.
     wrenEnsureSlots(otherVM, 2);
 
-    result = wrenInterpret(otherVM, "main", "1 + 2");
+    // Calling a foreign function should succeed.
+    result = wrenInterpret(otherVM, "main", "Random.new(12345)");
     correct = correct && (result == WREN_RESULT_SUCCESS);
 
     wrenEnsureSlots(otherVM, 2);


### PR DESCRIPTION
Hi,
344d343 doesn't fully fix the issue. This one also test and fix using foreign call using *broken* wrenInterpret.