### PR TITLE
Remove Lua from list of broken "this" langs

### DIFF
--- a/doc/site/classes.markdown
+++ b/doc/site/classes.markdown
@@ -213,7 +213,7 @@ class Unicorn {
 
 [function]: functions.html
 
-This is unlike Lua and JavaScript which can "forget" `this` when you create a
+This is unlike JavaScript which can "forget" `this` when you create a
 callback inside a method. Wren does what you want here and retains the
 reference to the original object.
 


### PR DESCRIPTION
Lua has lexical `self` and does not have any mechanism like JavaScript's `this`.

Example:

```lua
function class(init)
  local c,mt = {},{}
  c.__index = c
  mt.__call = function(class_tbl, ...)
    local obj = {}
    setmetatable(obj,c)
    init(obj,...)
    return obj
  end
  setmetatable(c, mt)
  return c
end

Range = class(function(self, lo, hi)
  self.lo = lo
  self.hi = hi
end)

function Range:each(f)
  for i=self.lo, self.hi do
    f(i)
  end
end

Unicorn = class(function(self, name)
  self.name = name
end)

function Unicorn:printNameThrice()
  Range(1,3):each(function()
      print(self.name)
    end)
end

francis = Unicorn("Francis")
francis:printNameThrice()
```