### PR TITLE
runFile: Free file source before exiting the function

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -441,6 +441,7 @@
     WrenInterpretResult result = wrenInterpret(vm, module->chars, source);
 
     pathFree(module);
+    free(source);
 
     return result;
   }


### PR DESCRIPTION
This prevents a memleak, noticeable when running `wren_test` under
`valgrind`. For example, the following command would leak

```sh
./bin/wren_test_d any_example.wren
```