### PR TITLE
[0.4.0] allow import strings to use string interpolation

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1281,7 +1281,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
       // value. It will be popped after this fiber is resumed. Store the
       // imported module's closure in the slot in case a GC happens when
       // invoking the closure.
-      PUSH(importModule(vm, fn->constants.data[READ_SHORT()]));
+      PUSH(importModule(vm, POP()));
       if (wrenHasError(fiber)) RUNTIME_ERROR();
       
       // If we get a closure, call it to execute the module body.


### PR DESCRIPTION
Adds the ability to do:
```js
import "configs/%(which_config)" for Config
```

I wanted to open this as a PR for interest sake and discussion purposes.
Disclaimer: I'm not sure yet if this is a good idea due to the thoughts below.

The biggest downside to this is that the determinism of import paths at compile time is lost. 
This means for things like code completion, static analysis etc you don't have a simple string any more, 
but rather expressions that can only be answered through execution of the code. **BUT**.

Note that this only applies to the string itself, not the result/contents of said string. 
For example, `import "http://127.0.0.1/api/random_quote" for Quote` is not somehow deterministic to code completion. The implementation details of the result of the import are entirely up to the host, not the code completion handler. 

The import path string is opaque, and in theory, has no meaning without a host giving it some. 
**There is no escaping that the host has to answer these questions for those systems to function, somehow.**

Another example from my own implementation details. 
Module imports follow a pattern where `package: file` is used, which means the host needs to explain:
- how to find `package: file`
- which includes knowing where `package` is located but also
- which `version` is used, as well as other project specific details

Just some things to think on, interested in hearing thoughts.

(Edit: not sure why it says the tests are failing, they all pass locally. Will figure it out later.)
