### PR TITLE
[0.4.0] Introduce WrenLoadModuleResult, fix unfreed strings from host.

### DIFF
--- a/doc/site/embedding/configuring-the-vm.markdown
+++ b/doc/site/embedding/configuring-the-vm.markdown
@@ -47,22 +47,53 @@ for a module.
 The signature of this function is:
 
 <pre class="snippet" data-lang="c">
-char* loadModule(WrenVM* vm, const char* name)
+WrenLoadModuleResult loadModule(WrenVM* vm, const char* name)
 </pre>
 
 When a module is imported, Wren calls this and passes in the module's name. The
-host should return the source code for that module. Memory for the source should
-be allocated using the same allocator that the VM uses for other allocation (see
-below). Wren will take ownership of the returned string and free it later.
+host should return the source code for that module in a `WrenLoadModuleResult` struct.
+
+<pre class="snippet" data-lang="c">
+WrenLoadModuleResult myLoadModule(WrenVM* vm, const char* name) {
+  WrenLoadModuleResult result = {0};
+    result.source = getSourceForModule(name);
+  return result;
+}
+</pre>
 
 The module loader is only be called once for any given module name. Wren caches
 the result internally so subsequent imports of the same module use the
 previously loaded code.
 
 If your host application isn't able to load a module with some name, it should
-return `NULL` and Wren will report that as a runtime error.
+make sure the `source` value is `NULL` when returned. Wren will then report that as a runtime error.
 
-If you don't use any `import` statements, you can leave this `NULL`.
+If you don't use any `import` statements, you can leave the `loadModuleFn` field in
+the configuration set to `NULL` (the default).
+
+Additionally, the `WrenLoadModuleResult` allows us to add a callback for when Wren is 
+done with the `source`, so we can free the memory if needed.
+
+<pre class="snippet" data-lang="c">
+
+static void loadModuleComplete(WrenVM* vm, 
+                               const char* module,
+                               WrenLoadModuleResult result) 
+{
+  if(result.source) {
+    //for example, if we used malloc to allocate
+    our source string, we use free to release it.
+    free((void*)result.source);
+  }
+}
+
+WrenLoadModuleResult myLoadModule(WrenVM* vm, const char* name) {
+  WrenLoadModuleResult result = {0};
+    result.onComplete = loadModuleComplete;
+    result.source = getSourceForModule(name);
+  return result;
+}
+</pre>
 
 ### **`bindForeignMethodFn`**
 

--- a/doc/site/modularity.markdown
+++ b/doc/site/modularity.markdown
@@ -81,17 +81,17 @@ WrenVM* vm = wrenNewVM(&config);
 That function has this signature:
 
 <pre class="snippet" data-lang="c">
-char* WrenLoadModuleFn(WrenVM* vm, const char* name);
+WrenLoadModuleResult WrenLoadModuleFn(WrenVM* vm, const char* name);
 </pre>
 
 Whenever a module is imported, the VM calls this and passes it the name of the
 module. The embedder is expected to return the source code contents of the
-module. When you embed Wren in your app, you can handle this however you want:
-reach out to the file system, look inside resources bundled into your app,
-whatever.
+module in a `WrenLoadModuleResult`. When you embed Wren in your app, you can handle
+this however you want: reach out to the file system, look inside resources bundled
+into your app, whatever.
 
-You can return `NULL` from this function to indicate that a module couldn't be
-found. When you do this, Wren will report it as a runtime error.
+You can return the source field as `NULL` from this function to indicate that a module
+couldn't be found. When you do this, Wren will report it as a runtime error.
 
 ### The command-line loader
 

--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -78,7 +78,6 @@ typedef void (*WrenLoadModuleCompleteFn)(WrenVM* vm, const char* name, WrenLoadM
 // [onComplete] an optional callback that will be called once Wren is done with the result.
 typedef struct WrenLoadModuleResult
 {
-  long long length;
   const char* source;
   WrenLoadModuleCompleteFn onComplete;
   void* userData;

--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -65,8 +65,26 @@ typedef void (*WrenFinalizerFn)(void* data);
 typedef const char* (*WrenResolveModuleFn)(WrenVM* vm,
     const char* importer, const char* name);
 
+// Forward declare
+typedef struct WrenLoadModuleResult WrenLoadModuleResult;
+
+// Called after loadModuleFn is called for module [name]. The original returned result
+// is handed back to you in this callback, so that you can free memory if appropriate.
+typedef void (*WrenLoadModuleCompleteFn)(WrenVM* vm, const char* name, WrenLoadModuleResult result);
+
+// The result of a loadModuleFn call. 
+// [length] is optional, a value of 0 means length is ignored.
+// [source] is the source code for the module, or NULL if the module is not found.
+// [onComplete] an optional callback that will be called once Wren is done with the result.
+typedef struct WrenLoadModuleResult
+{
+  long long length;
+  const char* source;
+  WrenLoadModuleCompleteFn onComplete;
+} WrenLoadModuleResult;
+
 // Loads and returns the source code for the module [name].
-typedef char* (*WrenLoadModuleFn)(WrenVM* vm, const char* name);
+typedef WrenLoadModuleResult (*WrenLoadModuleFn)(WrenVM* vm, const char* name);
 
 // Returns a pointer to a foreign method on [className] in [module] with
 // [signature].

--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -81,6 +81,7 @@ typedef struct WrenLoadModuleResult
   long long length;
   const char* source;
   WrenLoadModuleCompleteFn onComplete;
+  void* userData;
 } WrenLoadModuleResult;
 
 // Loads and returns the source code for the module [name].

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -713,7 +713,6 @@ static Value importModule(WrenVM* vm, Value name)
   // If the host didn't provide it, see if it's a built in optional module.
   if (result.source == NULL)
   {
-    result.length = 0;
     result.onComplete = NULL;
     ObjString* nameString = AS_STRING(name);
 #if WREN_OPT_META

--- a/test/api/resolution.c
+++ b/test/api/resolution.c
@@ -14,7 +14,12 @@ static void reportError(WrenVM* vm, WrenErrorType type,
   if (type == WREN_ERROR_RUNTIME) printf("%s\n", message);
 }
 
-static char* loadModule(WrenVM* vm, const char* module)
+static void loadModuleComplete(WrenVM* vm, const char* module, WrenLoadModuleResult result)
+{
+  free((void*)result.source);
+}
+
+static WrenLoadModuleResult loadModule(WrenVM* vm, const char* module)
 {
   printf("loading %s\n", module);
 
@@ -27,10 +32,14 @@ static char* loadModule(WrenVM* vm, const char* module)
   {
     source = "System.print(\"ok\")";
   }
-
+   
   char* string = (char*)malloc(strlen(source) + 1);
   strcpy(string, source);
-  return string;
+
+  WrenLoadModuleResult result = {0};
+    result.onComplete = loadModuleComplete;
+    result.source = string;
+  return result;
 }
 
 static void runTestVM(WrenVM* vm, WrenConfiguration* configuration,

--- a/test/test.c
+++ b/test/test.c
@@ -364,7 +364,15 @@
     }
   }
 
-  char* readModule(WrenVM* vm, const char* module) 
+  void readModuleComplete(WrenVM* vm, const char* module, WrenLoadModuleResult result)
+  {
+    if (result.source) {
+      free((void*)result.source);
+      result.source = NULL;
+    }
+  }
+
+  WrenLoadModuleResult readModule(WrenVM* vm, const char* module) 
   {
 
     Path* filePath = pathNew(module);
@@ -375,8 +383,11 @@
     char* source = readFile(filePath->chars);
     pathFree(filePath);
 
-    //may or may not be null
-    return source;
+    //source may or may not be null
+    WrenLoadModuleResult result;
+      result.source = source;
+      result.onComplete = readModuleComplete;
+    return result;
 
   }
 

--- a/test/test.h
+++ b/test/test.h
@@ -59,7 +59,7 @@ typedef struct
   PathType pathType(const char* path);
 //file helpers
   char* readFile(const char* path);
-  char* readModule(WrenVM* vm, const char* module);
+  WrenLoadModuleResult readModule(WrenVM* vm, const char* module);
 //vm helpers
   void vm_write(WrenVM* vm, const char* text);
   void reportError(WrenVM* vm, WrenErrorType type, const char* module, int line, const char* message);


### PR DESCRIPTION
The original attempt at handling the returns from loadModuleFn wasn't ideal. 
See https://github.com/wren-lang/wren/commit/889cae5ff1d870dd6c8443d81fabcb94cbde7e87, where it will attempt to free strings returned from the host unconditionally, assuming the host will allocate via the VM. This isn't a good workflow, and there are many origins for source that are not to be freed (and shouldn't be duplicated into VM memory for no reason).

Instead of making the host go via the VM allocation and need to understand it semantically, we can instead solve the problem of the unfreed return result directly. This also opens up the option of providing a length parameter or other information needed later (length is optional, **and not used as of right now**, but exists to show intent).

By making the callback part of the struct, it makes the result more useful in situations where you may return a fixed string (that shouldn't get freed) in one code path, and another in the same function where it must. Each returned string then, gets to decide whether it needs the callback, which simplifies host implementation significantly. Otherwise, logic from `loadModuleFn` needs to be duplicated into the complete callback redundantly, which can be bad for many reasons. This places the reasoning on the right side of the line at the call site. 

The basic usage is to return a struct with the source, instead of the source directly:
```cpp
  WrenLoadModuleResult result = {0};
    result.onComplete = loadModuleComplete;
    result.source = string;
  return result;
```

But as seen, an `onComplete` callback may be added to be notified when the vm is done with your source.
```cpp
static void loadModuleComplete(WrenVM* vm, const char* module, WrenLoadModuleResult result)
{
  free((void*)result.source);
}
```

As an additional note, this means that an (uncapturing) lambda can be used in place as well,
```cpp
result.onComplete = [](WrenVM* vm, const char* module, WrenLoadModuleResult result) {
  free((void*)result.source);
};
```