### PR TITLE
test: Fix some tests so they fail on expected error, not on syntax error.

### DIFF
--- a/test/language/constructor/cannot_be_infix.wren
+++ b/test/language/constructor/cannot_be_infix.wren
@@ -1,5 +1,5 @@
 class Foo {
-  this +(value) { // expect error
+  construct +(value) { // expect error
     System.print("ok")
   }
 }

--- a/test/language/constructor/cannot_be_minus.wren
+++ b/test/language/constructor/cannot_be_minus.wren
@@ -1,5 +1,5 @@
 class Foo {
-  this -(value) { // expect error
+  construct -(value) { // expect error
     System.print("ok")
   }
 }

--- a/test/language/constructor/cannot_be_setter.wren
+++ b/test/language/constructor/cannot_be_setter.wren
@@ -1,5 +1,5 @@
 class Foo {
-  this name=(value) { // expect error
+  construct name=(value) { // expect error
     System.print("ok")
   }
 }

--- a/test/language/constructor/cannot_be_subscript.wren
+++ b/test/language/constructor/cannot_be_subscript.wren
@@ -1,5 +1,5 @@
 class Foo {
-  this [value] { // expect error
+  construct [value] { // expect error
     System.print("ok")
   }
 }

--- a/test/language/constructor/cannot_be_unary.wren
+++ b/test/language/constructor/cannot_be_unary.wren
@@ -1,5 +1,5 @@
 class Foo {
-  this ! { // expect error
+  construct ! { // expect error
     System.print("ok")
   }
 }

--- a/test/language/constructor/no_parameter_list.wren
+++ b/test/language/constructor/no_parameter_list.wren
@@ -1,5 +1,5 @@
 class Foo {
-  this new { // expect error
+  construct new { // expect error
     System.print("ok")
   }
 }

--- a/test/limit/too_many_function_parameters.wren
+++ b/test/limit/too_many_function_parameters.wren
@@ -1,1 +1,1 @@
-var f = new Fn {|a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q| "!" } // expect error
+var f = Fn.new {|a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q| "!" } // expect error


### PR DESCRIPTION
A bunch of tests fails for the wrong reasons, based on some abandoned syntax. This patch fix the one I found using an updated version of wrenalyzer.