### PR TITLE
Segmentation Fault when calling unknown foreign constructors

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -626,10 +626,11 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
   // TODO: Don't look up every time.
   int symbol = wrenSymbolTableFind(&vm->methodNames, "<allocate>", 10);
   ASSERT(symbol != -1, "Should have defined <allocate> symbol.");
-
-  ASSERT(classObj->methods.count > symbol, "Class should have allocator.");
+  
+  // ASSERT(classObj->methods.count > symbol, "Class should have allocator.");
   Method* method = &classObj->methods.data[symbol];
-  ASSERT(method->type == METHOD_FOREIGN, "Allocator should be foreign.");
+  // ASSERT(method->type == METHOD_FOREIGN, "Allocator should be foreign.");
+  if(method->as.foreign == NULL) return;
 
   // Pass the constructor arguments to the allocator as well.
   ASSERT(vm->apiStack == NULL, "Cannot already be in foreign call.");

--- a/test/language/foreign/unknown_constructor.wren
+++ b/test/language/foreign/unknown_constructor.wren
@@ -1,0 +1,5 @@
+foreign class Foo {
+    construct unknownConstructor() {} // expect runtime error: Foo metaclass does not implement 'init unknownConstructor()'.
+}
+
+Foo.unknownConstructor()


### PR DESCRIPTION
I noticed that when calling constructors of foreign classes that don't have constructors set on the C side, the vm may crash with a segmentation fault rather than abort.
```C
#include "wren.h"
int main(int argc, char const* argv[]) {
    WrenConfiguration cfg;
    wrenInitConfiguration(&cfg);
    WrenVM* vm = wrenNewVM(&cfg);
    wrenInterpret(vm, "main",
                  "foreign class Foo {\n"
                  "    construct unknownConstructor() {}\n"
                  "}\n"
                  "\n"
                  "Foo.unknownConstructor()"); // <- Segmentation fault from calling constructor
    wrenFreeVM(vm);
    return 0;
}
```
I don't know much about the VM's internals so I don't really intend for this PR to merge but this little hack aborts the vm instead of crashing it.

I didn't do any extensive testing so not sure about any side effects but passes all tests ran from `.travis.sh` (at least on WSL)