### PR TITLE
Fix broken link

### DIFF
--- a/doc/site/variables.markdown
+++ b/doc/site/variables.markdown
@@ -31,7 +31,7 @@ System.print(a) //! "a" doesn't exist anymore.
 </pre>
 
 Variables defined at the top level of a script are *top-level* and are visible
-to the [module](modules.html) system. All other variables are *local*.
+to the [module](modularity.html) system. All other variables are *local*.
 Declaring a variable in an inner scope with the same name as an outer one is
 called *shadowing* and is not an error (although it's not something you likely
 intend to do much).


### PR DESCRIPTION
The Variables guide linked to `/modules.html`, but the page talking about modules is `/modularity.html`