### PR TITLE
Add Meson build file

### DIFF
--- a/doc/site/getting-started.markdown
+++ b/doc/site/getting-started.markdown
@@ -32,6 +32,7 @@ In here you'll find ready to go projects for `Visual Studio`, `XCode` and tools 
  * **Windows** Open `wren.sln` inside `projects/vs2019/` (or `vs2017`), hit build.
  * **Mac** Open `wren.xcworkspace` inside `projects/xcode/`, hit build.
  * **Linux** Run `make` inside of `projects/make/`.
+ * **Cross-platform** Run `meson build` inside of the root of the project, then run `ninja` in `build/`
 
 In each case, **there will be library files generated into the root `lib/` folder**.   
 These are what you'll link into your project, based on your needs.

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,67 @@
+project('wren', 'c', default_options: ['c_std=c99'])
+
+cc = meson.get_compiler('c')
+
+libm = cc.find_library('m')
+test_cmd = find_program('test')
+egrep_cmd = find_program('egrep')
+find_cmd = find_program('find')
+
+src = 'src'
+include = src / 'include'
+optional = src / 'optional'
+vm = src / 'vm'
+
+source = files(
+    optional / 'wren_opt_meta.c',
+    optional / 'wren_opt_random.c',
+    vm / 'wren_compiler.c',
+    vm / 'wren_core.c',
+    vm / 'wren_debug.c',
+    vm / 'wren_primitive.c',
+    vm / 'wren_utils.c',
+    vm / 'wren_value.c',
+    vm / 'wren_vm.c'
+)
+
+includes = include_directories(include, vm, optional)
+
+lib = both_libraries('wren', source,
+    include_directories: includes,
+    dependencies: [libm],
+    install: true)
+
+install_headers(include / 'wren.h', include / 'wren.hpp')
+
+test = 'test'
+api = test / 'api'
+
+api_tests = run_command(find_cmd, 'test/api', '-name', '*.wren').stdout().strip().split('\n')
+
+other_tests = run_command(find_cmd, 'test', '-path', 'test/api', '-prune', '-o', '-name', '*.wren').stdout().strip().split('\n')
+
+test_source = files(
+    test / 'main.c',
+    test / 'test.c',
+    api / 'api_tests.c',
+    api / 'benchmark.c'
+)
+
+foreach t : api_tests
+    c_file = t.split('.')[0] + '.c'
+    if run_command(test_cmd, '-f', c_file).returncode() == 0
+        test_source += c_file
+    endif
+endforeach
+
+test_includes = include_directories(include)
+
+wren_test = executable('wren_test', test_source,
+    link_with: [lib],
+    include_directories: test_includes)
+foreach t : (other_tests + api_tests)
+    if t != 'test/api'
+        should_fail = run_command(egrep_cmd, 'expect.* error', t).returncode() == 0
+        test(t, wren_test, workdir: meson.current_source_dir(), args: [t], should_fail: should_fail)
+    endif
+endforeach


### PR DESCRIPTION
This makes it easier to embed Wren into Meson-based projects, as now all
you need to do is add it as a subproject.