### PR TITLE
Use bitwise shifts when parsing hexadecimal numbers instead of multiply

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -825,7 +825,7 @@ static int readHexEscape(Parser* parser, int digits, const char* description)
       break;
     }
 
-    value = (value * 16) | digit;
+    value = (value << 4) | digit;
   }
 
   return value;


### PR DESCRIPTION
That is, `<< 4` instead of `* 16`

Why? Because we already use bitwise or instead of plus (`| digit` and not `+ digit`

No, it's NOT faster: compilers will optimize it to the same form (bitwise shift, of course)