### PR TITLE
Fix svg link to travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you like the sound of this, [let's get started][started]. You can even try
 it [in your browser][browser]! Excited? Well, come on and [get
 involved][contribute]!
 
-[![Build Status](https://travis-ci.org/wren-lang/wren.svg)](https://travis-ci.org/wren-lang/wren)
+[![Build Status](https://travis-ci.org/wren-lang/wren.svg?branch=main)](https://travis-ci.org/wren-lang/wren)
 
 [syntax]: http://wren.io/syntax.html
 [src]: https://github.com/wren-lang/wren/tree/main/src


### PR DESCRIPTION
Hey wren team,

I noticed that your travis build badge was displaying 'error' even though you had a passing build. Turns out you need to specify the branch url parameter. I hope this is helpful, feel free to reject if not 🙂

Thaaaanks!

P.S. I'm really enjoying 'Crafting Interpreters' @munificent 