### PR TITLE
docs: fix simple typo, similiar -> similar

### DIFF
--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -195,7 +195,7 @@ typedef struct sObjUpvalue
 
 // The type of a primitive function.
 //
-// Primitives are similiar to foreign functions, but have more direct access to
+// Primitives are similar to foreign functions, but have more direct access to
 // VM internals. It is passed the arguments in [args]. If it returns a value,
 // it places it in `args[0]` and returns `true`. If it causes a runtime error
 // or modifies the running fiber, it returns `false`.


### PR DESCRIPTION
There is a small typo in src/vm/wren_value.h.

Should read `similar` rather than `similiar`.

