### PR TITLE
Fix deprecated Python timing in benchmark & give more error info.

### DIFF
--- a/test/benchmark/binary_trees.py
+++ b/test/benchmark/binary_trees.py
@@ -29,7 +29,7 @@ min_depth = 4
 max_depth = 12
 stretch_depth = max_depth + 1
 
-start = time.clock()
+start = time.process_time()
 print("stretch tree of depth %d check:" % stretch_depth, check_tree(make_tree(0, stretch_depth)))
 
 long_lived_tree = make_tree(0, max_depth)
@@ -45,4 +45,4 @@ for depth in range(min_depth, stretch_depth, 2):
     iterations //= 4
 
 print("long lived tree of depth %d check:" % max_depth, check_tree(long_lived_tree))
-print("elapsed: " + str(time.clock() - start))
+print("elapsed: " + str(time.process_time() - start))

--- a/test/benchmark/delta_blue.py
+++ b/test/benchmark/delta_blue.py
@@ -625,12 +625,12 @@ planner = None
 
 def delta_blue():
     global total
-    start = time.clock()
+    start = time.process_time()
     for i in range(40):
         chain_test(100)
         projection_test(100)
     print(total)
-    print("elapsed: " + str(time.clock() - start))
+    print("elapsed: " + str(time.process_time() - start))
 
 
 if __name__ == '__main__':

--- a/test/benchmark/fib.py
+++ b/test/benchmark/fib.py
@@ -6,7 +6,7 @@ def fib(n):
   if n < 2: return n
   return fib(n - 1) + fib(n - 2)
 
-start = time.clock()
+start = time.process_time()
 for i in range(0, 5):
   print(fib(28))
-print("elapsed: " + str(time.clock() - start))
+print("elapsed: " + str(time.process_time() - start))

--- a/test/benchmark/for.py
+++ b/test/benchmark/for.py
@@ -8,7 +8,7 @@ try:
 except NameError:
     pass
 
-start = time.clock()
+start = time.process_time()
 list = []
 for i in range(0, 1000000):
   list.append(i)
@@ -17,4 +17,4 @@ sum = 0
 for i in list:
   sum += i
 print(sum)
-print("elapsed: " + str(time.clock() - start))
+print("elapsed: " + str(time.process_time() - start))

--- a/test/benchmark/map_numeric.py
+++ b/test/benchmark/map_numeric.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import time
 
-start = time.clock()
+start = time.process_time()
 
 map = {}
 
@@ -17,4 +17,4 @@ print(sum)
 for i in range(1, 2000001):
   del map[i]
 
-print("elapsed: " + str(time.clock() - start))
+print("elapsed: " + str(time.process_time() - start))

--- a/test/benchmark/map_string.py
+++ b/test/benchmark/map_string.py
@@ -78,7 +78,7 @@ for animal in animals:
     for adverb in adverbs:
       keys.append(adverb + " " + adjective + " " + animal)
 
-start = time.clock()
+start = time.process_time()
 
 map = {}
 i = 0
@@ -94,4 +94,4 @@ for key in keys:
   del map[key]
 
 print(sum)
-print("elapsed: " + str(time.clock() - start))
+print("elapsed: " + str(time.process_time() - start))

--- a/test/benchmark/method_call.py
+++ b/test/benchmark/method_call.py
@@ -34,7 +34,7 @@ class NthToggle(Toggle):
 
 
 def main():
-    start = time.clock()
+    start = time.process_time()
 
     NUM = 100000
 
@@ -74,7 +74,7 @@ def main():
     else:
         print("false")
 
-    print("elapsed: " + str(time.clock() - start))
+    print("elapsed: " + str(time.process_time() - start))
 
 
 main()

--- a/test/benchmark/string_equals.py
+++ b/test/benchmark/string_equals.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import time
-start = time.clock()
+start = time.process_time()
 
 count = 0
 for i in range(0, 1000000):
@@ -32,4 +32,4 @@ for i in range(0, 1000000):
       count = count + 1
 
 print(count)
-print("elapsed: " + str(time.clock() - start))
+print("elapsed: " + str(time.process_time() - start))

--- a/util/benchmark.py
+++ b/util/benchmark.py
@@ -182,9 +182,9 @@ def run_benchmark_language(benchmark, language, benchmark_result):
   name = "{0} - {1}".format(benchmark[0], language[0])
   print("{0:30s}".format(name), end=' ')
 
-  if not os.path.exists(os.path.join(
-      BENCHMARK_DIR, benchmark[0] + language[2])):
-    print("No implementation for this language")
+  bpath = os.path.join(BENCHMARK_DIR, benchmark[0] + language[2])
+  if not os.path.exists(bpath):
+    print("No implementation for this language: " + bpath)
     return
 
   times = []


### PR DESCRIPTION
- Note: process_time gives CPU time used and perf_counter is absolute time used.
- Looks to have noise of about 1-2%.