### PR TITLE
Fix returning from constructors

### DIFF
--- a/doc/site/classes.markdown
+++ b/doc/site/classes.markdown
@@ -347,6 +347,20 @@ overloaded by [arity](#signature). A constructor *must* be a named method with
 a (possibly empty) argument list. Operators, getters, and setters cannot be
 constructors.
 
+A constructor returns the instance of the class being created, even if you 
+don't explicitly use `return`. It is valid to use `return` inside of a 
+constructor, but it is an error to have an expression after the return.
+That rule applies to `return this` as well, return handles that implicitly inside
+a constructor, so just `return` is enough.
+
+<pre class="snippet">
+return          //> valid, returns 'this'
+
+return variable //> invalid
+return null     //> invalid
+return this     //> also invalid
+</pre>
+
 A constructor is actually a pair of methods. You get a method on the class:
 
 <pre class="snippet">

--- a/test/language/constructor/cannot_return_value.wren
+++ b/test/language/constructor/cannot_return_value.wren
@@ -1,5 +1,5 @@
 class Foo {
   construct new() {
-    return 1 // expect error: Cannot return a value from constructor.
+    return 1 // expect error: A constructor cannot return a value.
   }
 }

--- a/test/language/constructor/cannot_return_value.wren
+++ b/test/language/constructor/cannot_return_value.wren
@@ -1,5 +1,5 @@
 class Foo {
   construct new() {
-    return 1 // expect error: A constructor cannot return a value.
+    return 1 // expect error
   }
 }

--- a/test/language/constructor/cannot_return_value.wren
+++ b/test/language/constructor/cannot_return_value.wren
@@ -1,0 +1,5 @@
+class Foo {
+  construct new() {
+    return 1 // expect error: Cannot return a value from constructor.
+  }
+}

--- a/test/language/constructor/return_without_value.wren
+++ b/test/language/constructor/return_without_value.wren
@@ -1,0 +1,7 @@
+class Foo {
+  construct new() {
+    return
+  }
+}
+System.print(Foo.new()) // expect: instance of Foo
+System.print(Foo.new() != null) // expect: true

--- a/test/language/constructor/return_without_value.wren
+++ b/test/language/constructor/return_without_value.wren
@@ -1,7 +1,18 @@
+class Baz {
+  construct new() {}
+}
+
+class Bar {
+  construct new() {
+  }
+}
+
 class Foo {
   construct new() {
     return
   }
 }
+System.print(Baz.new()) // expect: instance of Baz
+System.print(Bar.new()) // expect: instance of Bar
 System.print(Foo.new()) // expect: instance of Foo
 System.print(Foo.new() != null) // expect: true


### PR DESCRIPTION
 1. Do not allow returning with a value
 2. Return the instance, correctly, even when the user returned explicitly