### PR TITLE
Fix hash mask

### DIFF
--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -360,9 +360,8 @@ static inline uint32_t hashBits(uint64_t hash)
 {
   // From v8's ComputeLongHash() which in turn cites:
   // Thomas Wang, Integer Hash Functions.
-  // http://www.concentric.net/~Ttwang/tech/inthash.htm
+  // https://web.archive.org/web/20071223173210/http://www.concentric.net/~Ttwang/tech/inthash.htm
   // V8 version masks off top bit, whilst Wang's version does not:
-  // https://gist.github.com/badboy/6267743
   hash = ~hash + (hash << 18);  // hash = (hash << 18) - hash - 1;
   hash = hash ^ (hash >> 31);
   hash = hash * 21;  // hash = (hash + (hash << 2)) + (hash << 4);

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -361,13 +361,15 @@ static inline uint32_t hashBits(uint64_t hash)
   // From v8's ComputeLongHash() which in turn cites:
   // Thomas Wang, Integer Hash Functions.
   // http://www.concentric.net/~Ttwang/tech/inthash.htm
+  // V8 version masks off top bit, whilst Wang's version does not:
+  // https://gist.github.com/badboy/6267743
   hash = ~hash + (hash << 18);  // hash = (hash << 18) - hash - 1;
   hash = hash ^ (hash >> 31);
   hash = hash * 21;  // hash = (hash + (hash << 2)) + (hash << 4);
   hash = hash ^ (hash >> 11);
   hash = hash + (hash << 6);
   hash = hash ^ (hash >> 22);
-  return (uint32_t)(hash & 0x3fffffff);
+  return (uint32_t)hash;
 }
 
 // Generates a hash code for [num].


### PR DESCRIPTION
The hashing function which uses Thomas Wang's algorithm masks off the top bit, which isn't in Wang's algorithm. Masking the bit off effectively halves the hash space, which is already masked from 64 to 32 bits. Having a larger hash just reduces the chance of collisions.

Also fixed the hyperlink to the article as site link disappeared.