### PR TITLE
Use `fmin()` and `fmax()` in `Num.min(_)` and `Num.max(_)`

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -738,16 +738,12 @@ DEF_PRIMITIVE(num_atan2)
 
 DEF_PRIMITIVE(num_min)
 {
-  double value = AS_NUM(args[0]);
-  double other = AS_NUM(args[1]);
-  RETURN_NUM(value <= other ? value : other);
+  RETURN_NUM(fmin(AS_NUM(args[0]), AS_NUM(args[1])));
 }
 
 DEF_PRIMITIVE(num_max)
 {
-  double value = AS_NUM(args[0]);
-  double other = AS_NUM(args[1]);
-  RETURN_NUM(value > other ? value : other);
+  RETURN_NUM(fmax(AS_NUM(args[0]), AS_NUM(args[1])));
 }
 
 DEF_PRIMITIVE(num_clamp)


### PR DESCRIPTION
We already use those in `Range.min` and `Range.max`, and it's always better to use the standard library