### PR TITLE
In `List.+(other)`, `other` should be an iterable, list is not required

### DIFF
--- a/doc/site/modules/core/list.markdown
+++ b/doc/site/modules/core/list.markdown
@@ -165,7 +165,7 @@ It is a runtime error if the index is not an integer or is out of bounds.
 
 ##  **+**(other) operator
 
- Appends a list to the end of the list (concatenation). `other` must be a `List`.
+ Appends a list to the end of the list (concatenation). `other` must be [an iterable](../../control-flow.html#the-iterator-protocol).
 
 <pre class="snippet">
 var letters = ["a", "b", "c"]


### PR DESCRIPTION
We're iterating over it but do not check it's actually a list:

https://github.com/wren-lang/wren/blob/cb51d61a64f606df9436d74c3e78c407ade9dc95/src/vm/wren_core.wren#L363-L369