### PR TITLE
Add `Num.[max/min]SafeInteger`

### DIFF
--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -35,6 +35,14 @@ The largest representable numeric value.
 
 The smallest positive representable numeric value.
 
+### Num.**maxSafeInteger**
+
+The largest integer that all integers below it can be represented without precision loss.
+
+### Num.**minSafeInteger**
+
+The smallest integer that all integers above it can be represented without precision loss.
+
 ## Methods
 
 ### **abs**

--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -37,11 +37,14 @@ The smallest positive representable numeric value.
 
 ### Num.**maxSafeInteger**
 
-The largest integer that all integers below it can be represented without precision loss.
+The largest integer that Wren can safely represent. It's a constant value of `9007199254740991`.
+
+ This is relevant because Wren uses double precision [floating-point format](https://en.wikipedia.org/wiki/IEEE_floating_point)
+ for numbers, which can only safely represent integers between <code>-(2<sup>53</sup> - 1)</code> and <code>2<sup>53</sup> - 1</code>.
 
 ### Num.**minSafeInteger**
 
-The smallest integer that all integers above it can be represented without precision loss.
+The smallest integer Wren can safely represent. It's a constant value of `-9007199254740991`. 
 
 ## Methods
 

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -633,6 +633,9 @@ DEF_NUM_CONSTANT(tau,      6.28318530717958647692528676655900577)
 DEF_NUM_CONSTANT(largest,  DBL_MAX)
 DEF_NUM_CONSTANT(smallest, DBL_MIN)
 
+DEF_NUM_CONSTANT(maxSafeInteger, 9007199254740991.0)
+DEF_NUM_CONSTANT(minSafeInteger, -9007199254740991.0)
+
 // Defines a primitive on Num that calls infix [op] and returns [type].
 #define DEF_NUM_INFIX(name, op, type)                                          \
     DEF_PRIMITIVE(num_##name)                                                  \
@@ -1328,6 +1331,8 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->numClass->obj.classObj, "tau", num_tau);
   PRIMITIVE(vm->numClass->obj.classObj, "largest", num_largest);
   PRIMITIVE(vm->numClass->obj.classObj, "smallest", num_smallest);
+  PRIMITIVE(vm->numClass->obj.classObj, "maxSafeInteger", num_maxSafeInteger);
+  PRIMITIVE(vm->numClass->obj.classObj, "minSafeInteger", num_minSafeInteger);
   PRIMITIVE(vm->numClass, "-(_)", num_minus);
   PRIMITIVE(vm->numClass, "+(_)", num_plus);
   PRIMITIVE(vm->numClass, "*(_)", num_multiply);

--- a/test/core/number/maxSafeInteger.wren
+++ b/test/core/number/maxSafeInteger.wren
@@ -1,0 +1,1 @@
+System.print(Num.maxSafeInteger) // expect: 9.007199254741e+15

--- a/test/core/number/minSafeInteger.wren
+++ b/test/core/number/minSafeInteger.wren
@@ -1,0 +1,1 @@
+System.print(Num.minSafeInteger) // expect: -9.007199254741e+15


### PR DESCRIPTION
These represent the maximum and the minimum integers that all integers below/above them can be represented accurately (without precision loss), accordingly.

These constants are defined in JS ([`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), [`Number.MIN_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER)).

For example, the `fmt` module by PureFox48 needed `maxSafeInteger`, and hand-crafted it (https://github.com/NinjasCL-labs/wren-rosetta/blob/832a71ebfa1b817aa06bb9541408f8b6d9a652ef/src/fmt.wren#L18-L19). I thought it would be nice to have that built in.