### PR TITLE
Allow trailing comma on methods

### DIFF
--- a/test/language/function/parameters_trailing_comma.wren
+++ b/test/language/function/parameters_trailing_comma.wren
@@ -1,0 +1,3 @@
+var f = Fn.new {|a, b,| System.print("%(a) %(b)") }
+
+f.call(1, 2) // expect: 1 2

--- a/test/language/method/arguments_trailing_comma.wren
+++ b/test/language/method/arguments_trailing_comma.wren
@@ -1,0 +1,5 @@
+class Foo {
+  static method(a, b) { System.print("%(a) %(b)") }
+}
+
+Foo.method(1, 2,) // expect: 1 2

--- a/test/language/method/empty_subscript_call.wren
+++ b/test/language/method/empty_subscript_call.wren
@@ -1,3 +1,2 @@
 var list = [1, 2]
 list[] // expect error
-"don't actually want error here, but cascades from above" // expect error

--- a/test/language/method/parameters_trailing_comma.wren
+++ b/test/language/method/parameters_trailing_comma.wren
@@ -1,0 +1,5 @@
+class Foo {
+  static method(a, b,) { System.print("%(a) %(b)") }
+}
+
+Foo.method(1, 2) // expect: 1 2


### PR DESCRIPTION
That includes declaration and call, both methods, subscripts and block arguments.

The reasons are: a) we allow trailing commas on lists and maps, and b) git diff on multiline methods.

As a side benefit, we also get a more user-friendly error message in case of empty subscript or block argument's parameters list (`Fn.new {||}`).