### PR TITLE
added join as property in Sequence

### DIFF
--- a/src/vm/wren_core.wren
+++ b/src/vm/wren_core.wren
@@ -94,6 +94,7 @@ class Sequence {
     return result
   }
 
+  join { join("") }
   join() { join("") }
 
   join(sep) {

--- a/src/vm/wren_core.wren
+++ b/src/vm/wren_core.wren
@@ -94,7 +94,7 @@ class Sequence {
     return result
   }
 
-  join { join("") }
+  join { join() }
   join() { join("") }
 
   join(sep) {

--- a/src/vm/wren_core.wren.inc
+++ b/src/vm/wren_core.wren.inc
@@ -96,6 +96,8 @@ static const char* coreModuleSource =
 "    return result\n"
 "  }\n"
 "\n"
+"  join { join() }\n"
+"\n"
 "  join() { join(\"\") }\n"
 "\n"
 "  join(sep) {\n"

--- a/test/core/list/join.wren
+++ b/test/core/list/join.wren
@@ -7,6 +7,8 @@ System.print([1, 2, 3].join("")) // expect: 123
 // Handle a simple list with no separator.
 System.print([1, 2, 3].join()) // expect: 123
 
+System.print([1, 2, 3].join) // expect: 123
+
 // Does not quote strings.
 System.print([1, "2", true].join(",")) // expect: 1,2,true
 


### PR DESCRIPTION
This adds `join` as a property

```js
var nums = [1, 2, 3]
// 123
System.print(nums.join)
```

To be more inline with similar properties like `count`, `isEmpty` or `toList`