### PR TITLE
Report a runtime error when found an undefined foreign class

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -575,18 +575,23 @@ static void bindForeignClass(WrenVM* vm, ObjClass* classObj, ObjModule* module)
     }
 #endif
   }
+
+  if (methods.allocate == NULL)
+  {
+    ASSERT(methods.finalize == NULL, "Classes cannot have finalizer without allocator.");
+
+    vm->fiber->error = wrenStringFormat(vm,
+        "Could not find foreign class $ in module '$'.",
+        classObj->name->value, module->name->value);
+    return;
+  }
   
   Method method;
   method.type = METHOD_FOREIGN;
 
-  // Add the symbol even if there is no allocator so we can ensure that the
-  // symbol itself is always in the symbol table.
   int symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, "<allocate>", 10);
-  if (methods.allocate != NULL)
-  {
-    method.as.foreign = methods.allocate;
-    wrenBindMethod(vm, classObj, symbol, method);
-  }
+  method.as.foreign = methods.allocate;
+  wrenBindMethod(vm, classObj, symbol, method);
   
   // Add the symbol even if there is no finalizer so we can ensure that the
   // symbol itself is always in the symbol table.


### PR DESCRIPTION
In the previous code, such class made `ASSERT()` fail in debug mode, and triggered a segfault in production, in the better case. In the worse case, it was a security hole (UB) and all sorts of bad.
It was one of two - dereferencing an uninitialized pointer or out-of-bounds array access. Neither way a good thing, and security men are expert in seriously crafting code so it will hit the out-of-bounds case and to some sensitive data. We're all hate it.