### PR TITLE
Do not call `validateKey()` from `wrenGetMapContainsKey()`

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1822,7 +1822,6 @@ bool wrenGetMapContainsKey(WrenVM* vm, int mapSlot, int keySlot)
   ASSERT(IS_MAP(vm->apiStack[mapSlot]), "Slot must hold a map.");
 
   Value key = vm->apiStack[keySlot];
-  if (!validateKey(vm, key)) return false;
 
   ObjMap* map = AS_MAP(vm->apiStack[mapSlot]);
   Value value = wrenMapGet(map, key);


### PR DESCRIPTION
`validateKey()` will abort the fiber if given an unhashable key, which is unwanted.