### PR TITLE
wren/compiler: Store value in the correct token.

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -717,7 +717,7 @@ static void makeNumber(Parser* parser)
 {
   errno = 0;
 
-  parser->current.value = NUM_VAL(strtod(parser->tokenStart, NULL));
+  parser->next.value = NUM_VAL(strtod(parser->tokenStart, NULL));
   
   if (errno == ERANGE)
   {


### PR DESCRIPTION
Fix for 3a06580b89459553b866f27eb7ee8792b0310a76, incorect merge.
Due to 1c5ac288312cb0111b5eb15b6e234781f1f8b8bb, the value has now to be stored
in parser->next.