### PR TITLE
wren/compiler: Allow multiline empty parameter lists and calls.

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1876,6 +1876,9 @@ static void methodCall(Compiler* compiler, Code instruction,
   {
     called.type = SIG_METHOD;
 
+    // Allow new line before an empty argument list
+    ignoreNewlines(compiler);
+
     // Allow empty an argument list.
     if (peek(compiler) != TOKEN_RIGHT_PAREN)
     {
@@ -2547,6 +2550,9 @@ static void parameterList(Compiler* compiler, Signature* signature)
   
   signature->type = SIG_METHOD;
   
+  // Allow new line before an empty argument list
+  ignoreNewlines(compiler);
+
   // Allow an empty parameter list.
   if (match(compiler, TOKEN_RIGHT_PAREN)) return;
 

--- a/test/language/method/no_parameters_new_line.wren
+++ b/test/language/method/no_parameters_new_line.wren
@@ -1,0 +1,19 @@
+
+class Foo {
+  static call(
+        ) {
+    System.print("Success") // expect: Success
+  }
+
+  construct new () {}
+
+  call(
+        ) {
+    System.print("Success") // expect: Success
+  }
+}
+
+Foo.call(
+)
+Foo.new().call(
+)


### PR DESCRIPTION
An attempt to fix #924.

This patch only fix empty multiline method declarations and invocation, there can be other interesting place where we can allow multiline in parameters/arguments.