### PR TITLE
Add documentation for String * operator

### DIFF
--- a/doc/site/modules/core/string.markdown
+++ b/doc/site/modules/core/string.markdown
@@ -246,6 +246,12 @@ Returns a new string that concatenates this string and `other`.
 
 It is a runtime error if `other` is not a string.
 
+### *****(count) operator
+
+Returns a new string that contains this string repeated `count` times.
+
+It is a runtime error if `count` is not a positive integer.
+
 ### **==**(other) operator
 
 Checks if the string is equal to `other`.


### PR DESCRIPTION
Tiny update to the docs, adds a missing operator description for the *(count) operator on String