### PR TITLE
Tentative fix for Num class docs issue on the wren.io site.

### DIFF
--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -251,13 +251,13 @@ Performs bitwise exclusive or on the number. Both numbers are first converted to
 
 It is a runtime error if `other` is not a number.
 
-### **<<**(other) operator
+### **&lt;&lt;**(other) operator
 
 Performs a bitwise left shift on the number. Internally, both numbers are first converted to 32-bit unsigned values and C's left shift operator is then applied to them.
 
 It is a runtime error if `other` is not a number.
 
-### **>>**(other) operator
+### **&gt;&gt;**(other) operator
 
 Performs a bitwise right shift on the number. Internally, both numbers are first converted to 32-bit unsigned values and C's right shift operator is then applied to them.
 


### PR DESCRIPTION
I noticed today that, in the documentation for the ```Num``` class on the wren.io site, the explanation for the ```<<``` operator is not being displayed (at least on Firefox and Safari). It is being overwritten by the explanation for the ```..``` operator which, however, has lost its heading.

Although at first sight the markdown file looks OK, I suspect the reason for this is that we should be using HTML escapes for the ```>```characters  (and also for that matter the ```<``` characters). If so, this is my bad as I prepared the original PR when these docs were added.

I've therefore changed them in the hope this will fix the problem.