### PR TITLE
rename some test functions that clash with libc

### DIFF
--- a/test/api/maps.c
+++ b/test/api/maps.c
@@ -49,7 +49,7 @@ static void insert(WrenVM* vm)
   wrenSetMapValue(vm, 0, 1, 2);
 }
 
-static void removeWren(WrenVM* vm)
+static void removeKey(WrenVM* vm)
 {
   wrenEnsureSlots(vm, 3);
 
@@ -104,7 +104,7 @@ WrenForeignMethodFn mapsBindMethod(const char* signature)
 {
   if (strcmp(signature, "static Maps.newMap()") == 0) return newMap;
   if (strcmp(signature, "static Maps.insert()") == 0) return insert;
-  if (strcmp(signature, "static Maps.remove(_)") == 0) return removeWren;
+  if (strcmp(signature, "static Maps.remove(_)") == 0) return removeKey;
   if (strcmp(signature, "static Maps.count(_)") == 0) return countWren;
   if (strcmp(signature, "static Maps.count()") == 0) return countAPI;
   if (strcmp(signature, "static Maps.contains()") == 0) return containsAPI;

--- a/test/api/maps.c
+++ b/test/api/maps.c
@@ -49,7 +49,7 @@ static void insert(WrenVM* vm)
   wrenSetMapValue(vm, 0, 1, 2);
 }
 
-static void remove(WrenVM* vm)
+static void removeWren(WrenVM* vm)
 {
   wrenEnsureSlots(vm, 3);
 
@@ -104,7 +104,7 @@ WrenForeignMethodFn mapsBindMethod(const char* signature)
 {
   if (strcmp(signature, "static Maps.newMap()") == 0) return newMap;
   if (strcmp(signature, "static Maps.insert()") == 0) return insert;
-  if (strcmp(signature, "static Maps.remove(_)") == 0) return remove;
+  if (strcmp(signature, "static Maps.remove(_)") == 0) return removeWren;
   if (strcmp(signature, "static Maps.count(_)") == 0) return countWren;
   if (strcmp(signature, "static Maps.count()") == 0) return countAPI;
   if (strcmp(signature, "static Maps.contains()") == 0) return containsAPI;

--- a/test/api/resolution.c
+++ b/test/api/resolution.c
@@ -3,7 +3,7 @@
 
 #include "resolution.h"
 
-static void write(WrenVM* vm, const char* text)
+static void writeStdout(WrenVM* vm, const char* text)
 {
   printf("%s", text);
 }
@@ -45,7 +45,7 @@ static WrenLoadModuleResult loadModule(WrenVM* vm, const char* module)
 static void runTestVM(WrenVM* vm, WrenConfiguration* configuration,
                       const char* source)
 {
-  configuration->writeFn = write;
+  configuration->writeFn = writeStdout;
   configuration->errorFn = reportError;
   configuration->loadModuleFn = loadModule;
 

--- a/test/api/resolution.c
+++ b/test/api/resolution.c
@@ -3,7 +3,7 @@
 
 #include "resolution.h"
 
-static void writeStdout(WrenVM* vm, const char* text)
+static void writeFn(WrenVM* vm, const char* text)
 {
   printf("%s", text);
 }
@@ -45,7 +45,7 @@ static WrenLoadModuleResult loadModule(WrenVM* vm, const char* module)
 static void runTestVM(WrenVM* vm, WrenConfiguration* configuration,
                       const char* source)
 {
-  configuration->writeFn = writeStdout;
+  configuration->writeFn = writeFn;
   configuration->errorFn = reportError;
   configuration->loadModuleFn = loadModule;
 


### PR DESCRIPTION
While attempting to get Wren to compile under Cosmopolitan libc (see https://github.com/jart/cosmopolitan/issues/104), I discovered two test functions whose names clash with libc. This is not a problem when compiling against a standard libc, but with Cosmopolitan there is a "super header" that is included with `-include cosmopolitan.h` where all the functions are defined. This stops some tests from compiling, since they also define `write` and `remove`. This PR just renames those functions.

This is the only change to the Wren source code now required to get it building and all the tests passing under Cosmopolitan libc.

Something that might be interesting is adding a Cosmopolitan Premake action so that we can generate makefiles that just work without any tweaks, but that's something for the future, I think.