### PR TITLE
Added Go style variable declaration (:= operator)

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3488,7 +3488,7 @@ void definition(Compiler* compiler)
   {
     variableDefinition(compiler, false);
   }
-  else if(peek(compiler) == TOKEN_NAME && peekNext(compiler) == TOKEN_COLONEQ) 
+  else if (peek(compiler) == TOKEN_NAME && peekNext(compiler) == TOKEN_COLONEQ) 
   {
     variableDefinition(compiler, true);
   }

--- a/test/language/assignment/shorthand.wren
+++ b/test/language/assignment/shorthand.wren
@@ -1,0 +1,2 @@
+a := 42
+System.print(a) // expect: 42

--- a/test/language/assignment/shorthand_expression.wren
+++ b/test/language/assignment/shorthand_expression.wren
@@ -1,0 +1,1 @@
+System.print(a := "name") // expect error

--- a/test/language/assignment/shorthand_reassign.wren
+++ b/test/language/assignment/shorthand_reassign.wren
@@ -1,0 +1,2 @@
+a := "before"
+a := "after" // expect error


### PR DESCRIPTION
Added ability to declare variables using the `:=` operator just like in Go

This way, instead of:
```js
var a = "Hello world!"
```
we could shorten it to:
```js
a := "Hello world!"
```