### PR TITLE
Added pipe operator

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -72,6 +72,7 @@ typedef enum
   TOKEN_GTGT,
   TOKEN_PIPE,
   TOKEN_PIPEPIPE,
+  TOKEN_PIPEOPERATOR,
   TOKEN_CARET,
   TOKEN_AMP,
   TOKEN_AMPAMP,
@@ -982,7 +983,14 @@ static void nextToken(Parser* parser)
       case '~': makeToken(parser, TOKEN_TILDE); return;
       case '?': makeToken(parser, TOKEN_QUESTION); return;
         
-      case '|': twoCharToken(parser, '|', TOKEN_PIPEPIPE, TOKEN_PIPE); return;
+      case '|':
+        if (peekChar(parser) == '>') {
+          matchChar(parser, '>');
+          makeToken(parser, TOKEN_PIPEOPERATOR);
+          return;
+        }
+        twoCharToken(parser, '|', TOKEN_PIPEPIPE, TOKEN_PIPE);
+        return;
       case '&': twoCharToken(parser, '&', TOKEN_AMPAMP, TOKEN_AMP); return;
       case '=': twoCharToken(parser, '=', TOKEN_EQEQ, TOKEN_EQ); return;
       case '!': twoCharToken(parser, '=', TOKEN_BANGEQ, TOKEN_BANG); return;
@@ -1583,6 +1591,7 @@ typedef enum
   PREC_NONE,
   PREC_LOWEST,
   PREC_ASSIGNMENT,    // =
+  PREC_PIPEOPERATOR,  // |>
   PREC_CONDITIONAL,   // ?:
   PREC_LOGICAL_OR,    // ||
   PREC_LOGICAL_AND,   // &&
@@ -2632,6 +2641,7 @@ GrammarRule rules[] =
   /* TOKEN_GTGT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, ">>"),
   /* TOKEN_PIPE          */ INFIX_OPERATOR(PREC_BITWISE_OR, "|"),
   /* TOKEN_PIPEPIPE      */ INFIX(PREC_LOGICAL_OR, or_),
+  /* TOKEN_PIPEOPERATOR  */ INFIX_OPERATOR(PREC_PIPEOPERATOR, "|>"),
   /* TOKEN_CARET         */ INFIX_OPERATOR(PREC_BITWISE_XOR, "^"),
   /* TOKEN_AMP           */ INFIX_OPERATOR(PREC_BITWISE_AND, "&"),
   /* TOKEN_AMPAMP        */ INFIX(PREC_LOGICAL_AND, and_),

--- a/test/language/pipe_operator/functional.wren
+++ b/test/language/pipe_operator/functional.wren
@@ -1,0 +1,19 @@
+class Pipe {
+    construct new(value) {
+        _value = value
+    }
+
+    |> (other) {
+        return other.call(_value)
+    }
+
+    toString {_value}
+}
+
+var Concat = Fn.new {|message| Pipe.new(message + "World")}
+var Multiply = Fn.new {|message, count| Pipe.new(message * count)}
+var MultiplyCurried = Fn.new {|value| Multiply.call(value.toString, 2)}
+var Print = Fn.new {|message| System.print(message)}
+
+// It can help making functional composition easier
+Pipe.new("Hello") |> Concat |> MultiplyCurried |> Print // expect: HelloWorldHelloWorld

--- a/test/language/pipe_operator/precedence.wren
+++ b/test/language/pipe_operator/precedence.wren
@@ -1,0 +1,14 @@
+class Test {
+    construct new(value) {
+        _value = value
+    }
+
+    |> (other) {
+        return _value + other
+    }
+}
+
+// Pipe Operator is just above Assignment precedence
+var result = Test.new("Hello") |> "World" + "1"
+
+System.print(result) // expect: HelloWorld1

--- a/test/language/pipe_operator/simple_class.wren
+++ b/test/language/pipe_operator/simple_class.wren
@@ -1,0 +1,11 @@
+class Test {
+    construct new(value) {
+        _value = value
+    }
+
+    |> (other) {
+        System.print(_value + other)
+    }
+}
+
+Test.new("Hello") |> "World" // expect: HelloWorld


### PR DESCRIPTION
Regarding the conversation in https://github.com/wren-lang/wren/issues/941
It's clear that a pipe operator can help achieving functional composition with Wren.

Although this PR is focused only in the implementation of the Pipe operator itself `|>`
so any Class can implement its own behaviour. This will open the door for more functional utilities on top of the OOP nature of Wren.

Example:

```js
class Pipe {
    construct new(value) {
        _value = value
    }

    |> (other) {
        return other.call(_value)
    }

    toString {_value}
}

var Concat = Fn.new {|message| Pipe.new(message + "World")}
var Multiply = Fn.new {|message, count| Pipe.new(message * count)}
var MultiplyCurried = Fn.new {|value| Multiply.call(value.toString, 2)}
var Print = Fn.new {|message| System.print(message)}

// It can help making functional composition easier
Pipe.new("Hello") |> Concat |> MultiplyCurried |> Print // expect: HelloWorldHelloWorld
```