### PR TITLE
Extended valid identifier character list

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -593,98 +593,34 @@ static Keyword keywords[] =
 };
 
 
-// Add support for the extended characters as a valid name
-// Small subset of https://en.wikipedia.org/wiki/ISO/IEC_8859-1
-static bool isUTF8Name(char c) {
-  uint8_t ch = (uint8_t) c;
-  switch (ch) {
-    case 0xc2: // initial
-    case 0xc3: // initial
-    case 0xc5: // initial
-    case 0xce: // initial
-    case 0xcf: // initial
-    case 0xe2: // initial
-    case 0xa1: // á
-    case 0xa9: // é
-    case 0xad: // í
-    case 0xb3: // ó
-    case 0xba: // ú
-    case 0xa0: // à
-    case 0xa8: // è
-    case 0xac: // ì
-    case 0xb2: // ò
-    case 0xb9: // ù
-    case 0xa2: // â
-    case 0xaa: // ê
-    case 0xae: // î
-    case 0xb4: // ô
-    case 0xbb: // û
-    case 0xa4: // ä
-    case 0xab: // ë
-    case 0xaf: // ï
-    case 0xb6: // ö
-    case 0xbc: // ü
-    case 0x81: // Á
-    case 0x89: // É
-    case 0x8d: // Í
-    case 0x93: // Ó
-    case 0x9a: // Ú
-    case 0x80: // À
-    case 0x88: // È
-    case 0x8c: // Ì
-    case 0x92: // Ò
-    case 0x99: // Ù
-    case 0x82: // Â
-    case 0x8a: // Ê
-    case 0x8e: // Î
-    case 0x94: // Ô
-    case 0x9b: // Û
-    case 0x84: // Ä
-    case 0x8b: // Ë
-    case 0x8f: // Ï
-    case 0x96: // Ö
-    case 0x9c: // Ü
-    case 0xb1: // ñ
-    case 0xa7: // ç
-    case 0x91: // Ñ
-    case 0x87: // Ç
-    case 0xb7: // ·
-    case 0xb0: // °
-    case 0xb5: // µ õ
-    case 0x86: // Æ
-    case 0xa6: // æ
-    case 0x85: // Å
-    case 0xa5: // å
-    case 0x83: // Ã
-    case 0xa3: // ã
-    case 0x95: // Õ
-    case 0x98: // Ø
-    case 0xb8: // ø Ÿ
-    case 0x90: // Ð
-    case 0x9f: // ð ß
-    case 0x9d: // Ý
-    case 0xbd: // ý
-    case 0xbf: // ÿ
-    case 0x9e: // Þ
-    case 0xbe: // þ
-    case '$':  // $ ¥ ¢ £ ¤ €
-    case '@':  // @
-    // 0xe2 0x88 0x91 (∑)
-    // 0xce 0xb1 (α)
-    // 0xce 0xa9 (Ω)
-    // 0xcf 0x80 (π)
-    // 0xce 0x94 (Δ)
-    // 0xce 0xb3 (γ)
-      return true;
-    default:
-      return false;
-  }
-}
 // Returns true if [c] is a valid (non-initial) identifier character.
-static bool isName(char c)
+// Add support for the extended characters as a valid name
+static bool isAsciiName(uint8_t c)
 {
-  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || isUTF8Name(c);
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
 }
+
+static bool isUtf8Name(int c)
+{
+  if (c < 0 || c > 0x10ffff) {
+    return false;
+  }
+  
+  // Support the traditional Ascii only identifiers
+  if (c <= 0x7f && isAsciiName(c)) {
+    return true;
+  }
+
+  // Assume is a valid utf8 character
+  // If the value is above 127 (Ascii) and below maximum Utf8 value (bytes are lower than 4)
+  return (c > 0x7f && c <= 0x10ffff);
+}
+
+static bool isName(uint8_t c)
+{
+  return isUtf8Name(c);
+}
+
 
 // Returns true if [c] is a digit.
 static bool isDigit(char c)

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1153,7 +1153,7 @@ static void nextToken(Parser* parser)
         }
         else
         {
-          if ((c >= 32 && c <= 126))
+          if (c >= 32 && c <= 126)
           {
             lexError(parser, "Invalid character '%c'.", c);
           }

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -592,10 +592,79 @@ static Keyword keywords[] =
   {NULL,        0, TOKEN_EOF} // Sentinel to mark the end of the array.
 };
 
+
+// Add support for the extended characters as a valid name
+static bool isUTF8Name(char c) {
+  uint8_t ch = (uint8_t) c;
+  switch (ch) {
+    case 0xc2: // initial
+    case 0xc3: // initial
+    case 0xce: // initial
+    case 0xcf: // initial
+    case 0xe2: // initial
+    case 0xa1: // á
+    case 0xa9: // é
+    case 0xad: // í
+    case 0xb3: // ó
+    case 0xba: // ú
+    case 0xa0: // à
+    case 0xa8: // è
+    case 0xac: // ì
+    case 0xb2: // ò
+    case 0xb9: // ù
+    case 0xa2: // â
+    case 0xaa: // ê
+    case 0xae: // î
+    case 0xb4: // ô
+    case 0xbb: // û
+    case 0xa4: // ä
+    case 0xab: // ë
+    case 0xaf: // ï
+    case 0xb6: // ö
+    case 0xbc: // ü
+    case 0x81: // Á
+    case 0x89: // É
+    case 0x8d: // Í
+    case 0x93: // Ó
+    case 0x9a: // Ú
+    case 0x80: // À
+    case 0x88: // È
+    case 0x8c: // Ì
+    case 0x92: // Ò
+    case 0x99: // Ù
+    case 0x82: // Â
+    case 0x8a: // Ê
+    case 0x8e: // Î
+    case 0x94: // Ô
+    case 0x9b: // Û
+    case 0x84: // Ä
+    case 0x8b: // Ë
+    case 0x8f: // Ï
+    case 0x96: // Ö
+    case 0x9c: // Ü
+    case 0xb1: // ñ
+    case 0xa7: // ç
+    case 0x91: // Ñ
+    case 0x87: // Ç
+    case 0xb7: // ·
+    case 0xb0: // °
+    case '$':  // $
+    case '@':  // @
+    // 0xe2 0x88 0x91 (∑)
+    // 0xce 0xb1 (α)
+    // 0xce 0xa9 (Ω)
+    // 0xcf 0x80 (π)
+    // 0xce 0x94 (Δ)
+    // 0xce 0xb3 (γ)
+      return true;
+    default:
+      return false;
+  }
+}
 // Returns true if [c] is a valid (non-initial) identifier character.
 static bool isName(char c)
 {
-  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || isUTF8Name(c);
 }
 
 // Returns true if [c] is a digit.
@@ -1084,7 +1153,7 @@ static void nextToken(Parser* parser)
         }
         else
         {
-          if (c >= 32 && c <= 126)
+          if ((c >= 32 && c <= 126))
           {
             lexError(parser, "Invalid character '%c'.", c);
           }
@@ -1094,7 +1163,7 @@ static void nextToken(Parser* parser)
             // bytes. Since there are no non-ASCII byte values that are
             // meaningful code units in Wren, the lexer works on raw bytes,
             // even though the source code and console output are UTF-8.
-            lexError(parser, "Invalid byte 0x%x.", (uint8_t)c);
+            lexError(parser, "Invalid byte 0x%x. %d", (uint8_t)c, isName(c));
           }
           parser->next.type = TOKEN_ERROR;
           parser->next.length = 0;

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1163,7 +1163,7 @@ static void nextToken(Parser* parser)
             // bytes. Since there are no non-ASCII byte values that are
             // meaningful code units in Wren, the lexer works on raw bytes,
             // even though the source code and console output are UTF-8.
-            lexError(parser, "Invalid byte 0x%x.", (uint8_t)c;
+            lexError(parser, "Invalid byte 0x%x.", (uint8_t)c);
           }
           parser->next.type = TOKEN_ERROR;
           parser->next.length = 0;

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -594,11 +594,13 @@ static Keyword keywords[] =
 
 
 // Add support for the extended characters as a valid name
+// Small subset of https://en.wikipedia.org/wiki/ISO/IEC_8859-1
 static bool isUTF8Name(char c) {
   uint8_t ch = (uint8_t) c;
   switch (ch) {
     case 0xc2: // initial
     case 0xc3: // initial
+    case 0xc5: // initial
     case 0xce: // initial
     case 0xcf: // initial
     case 0xe2: // initial
@@ -648,7 +650,24 @@ static bool isUTF8Name(char c) {
     case 0x87: // Ç
     case 0xb7: // ·
     case 0xb0: // °
-    case '$':  // $
+    case 0xb5: // µ õ
+    case 0x86: // Æ
+    case 0xa6: // æ
+    case 0x85: // Å
+    case 0xa5: // å
+    case 0x83: // Ã
+    case 0xa3: // ã
+    case 0x95: // Õ
+    case 0x98: // Ø
+    case 0xb8: // ø Ÿ
+    case 0x90: // Ð
+    case 0x9f: // ð ß
+    case 0x9d: // Ý
+    case 0xbd: // ý
+    case 0xbf: // ÿ
+    case 0x9e: // Þ
+    case 0xbe: // þ
+    case '$':  // $ ¥ ¢ £ ¤ €
     case '@':  // @
     // 0xe2 0x88 0x91 (∑)
     // 0xce 0xb1 (α)

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1163,7 +1163,7 @@ static void nextToken(Parser* parser)
             // bytes. Since there are no non-ASCII byte values that are
             // meaningful code units in Wren, the lexer works on raw bytes,
             // even though the source code and console output are UTF-8.
-            lexError(parser, "Invalid byte 0x%x. %d", (uint8_t)c, isName(c));
+            lexError(parser, "Invalid byte 0x%x.", (uint8_t)c;
           }
           parser->next.type = TOKEN_ERROR;
           parser->next.length = 0;

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -594,33 +594,22 @@ static Keyword keywords[] =
 
 
 // Returns true if [c] is a valid (non-initial) identifier character.
-// Add support for the extended characters as a valid name
 static bool isAsciiName(uint8_t c)
 {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
 }
 
+// Adds Utf8 support the traditional Ascii only identifiers
+// Assume is a valid Utf8 character if it fits in the valid range
 static bool isUtf8Name(int c)
 {
-  if (c < 0 || c > 0x10ffff) {
-    return false;
-  }
-  
-  // Support the traditional Ascii only identifiers
-  if (c <= 0x7f && isAsciiName(c)) {
-    return true;
-  }
-
-  // Assume is a valid utf8 character
-  // If the value is above 127 (Ascii) and below maximum Utf8 value (bytes are lower than 4)
-  return (c > 0x7f && c <= 0x10ffff);
+  return isAsciiName(c) || (c > 0x7f && c <= 0x10ffff);
 }
 
 static bool isName(uint8_t c)
 {
   return isUtf8Name(c);
 }
-
 
 // Returns true if [c] is a digit.
 static bool isDigit(char c)

--- a/test/language/assignment/extended.wren
+++ b/test/language/assignment/extended.wren
@@ -1,0 +1,73 @@
+
+var á
+var é
+var í
+var ó
+var ú
+
+var à
+var è
+var ì
+var ò
+var ù
+
+var â
+var ê
+var î
+var ô
+var û
+
+var ä
+var ë
+var ï
+var ö
+var ü
+
+var Á
+var É
+var Í
+var Ó
+var Ú
+
+var À
+var È
+var Ì
+var Ò
+var Ù
+
+var Â
+var Ê
+var Î
+var Ô
+var Û
+
+var Ä
+var Ë
+var Ï
+var Ö
+var Ü
+
+var ñ
+var ç
+var Ñ
+var Ç
+
+// Special Symbols
+var ·
+var °
+var $
+var @
+var ∑
+var α
+var Ω
+var π
+var Δ
+var γ
+
+class Ñandú {
+    static ñandú { "Ñandú" }
+}
+
+var @Çlass$ = Ñandú
+
+System.print(@Çlass$.ñandú) // expect: Ñandú

--- a/test/language/assignment/extended.wren
+++ b/test/language/assignment/extended.wren
@@ -1,4 +1,4 @@
-
+// Subset of https://en.wikipedia.org/wiki/ISO/IEC_8859-1
 var á
 var é
 var í
@@ -55,7 +55,14 @@ var Ç
 // Special Symbols
 var ·
 var °
+
 var $
+var ¥
+var ¢
+var £
+var ¤
+var €
+
 var @
 var ∑
 var α
@@ -63,6 +70,36 @@ var Ω
 var π
 var Δ
 var γ
+
+var µ
+
+var Æ
+var æ
+
+var Å
+var å
+
+var Ã
+var ã
+
+var Õ
+var õ
+
+var Ø
+var ø
+
+var Ð
+var ð
+var ß
+
+var Ý
+var ý
+
+var Ÿ
+var ÿ
+
+var Þ
+var þ
 
 class Ñandú {
     static ñandú { "Ñandú" }

--- a/test/language/assignment/extended.wren
+++ b/test/language/assignment/extended.wren
@@ -1,4 +1,4 @@
-// Subset of https://en.wikipedia.org/wiki/ISO/IEC_8859-1
+
 var á
 var é
 var í
@@ -56,14 +56,12 @@ var Ç
 var ·
 var °
 
-var $
 var ¥
 var ¢
 var £
 var ¤
 var €
 
-var @
 var ∑
 var α
 var Ω
@@ -101,10 +99,15 @@ var ÿ
 var Þ
 var þ
 
+var 🐦 = "Wren"
+
 class Ñandú {
     static ñandú { "Ñandú" }
+    static 🇨🇱 { "Chile" }
 }
 
-var @Çlass$ = Ñandú
+var Çlass = Ñandú
 
-System.print(@Çlass$.ñandú) // expect: Ñandú
+System.print(Çlass.ñandú) // expect: Ñandú
+System.print(Ñandú.🇨🇱) // expect: Chile
+System.print(🐦) // expect: Wren


### PR DESCRIPTION
Regarding https://github.com/wren-lang/wren/issues/891

This implementation is not UTF-8 complete (no emojis).
But at least it gives a room for most roman/latin languages to use variable names
with non ascii chars + some symbols.

- Supported Characters: A small subset of https://en.wikipedia.org/wiki/ISO/IEC_8859-1