### PR TITLE
[Experiment] Added atoms

### DIFF
--- a/test/language/string/atom.wren
+++ b/test/language/string/atom.wren
@@ -1,0 +1,7 @@
+// A string that starts with $ and ends when a non valid identifier character is found
+// contains the same text.
+// Useful for Map keys.
+
+System.print($hello) // expect: hello
+
+System.print({ $hello: "Wren" }) // expect: {hello: Wren}


### PR DESCRIPTION
Wren does not need atoms at all since all the string literals are already stored by reference.
But is a nice syntax sugar when you need keys in a Map.

```js

System.print($hello) // expect: hello

System.print({ $hello: "Wren" }) // expect: {hello: Wren}
```

This was made just to know if it was possible.

The character `$` was used to delimit the start of an atom. Using `:` created some conflicts with maps so it was easier just to use a new previously unused character. Also it a character widely used in PHP and other languages so its not too strange to use it.