### PR TITLE
fix possibility of having no reallocate function

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -58,13 +58,11 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   if (config != NULL) {
     
     // ensure config has a reallocate function
-    if (config->reallocateFn != NULL) {
-      reallocate = config->reallocateFn;
-    }
-    else {
+    if (config->reallocateFn == NULL) {
       config->reallocateFn = defaultReallocate;
     }
 
+    reallocate = config->reallocateFn;
     userData = config->userData;
   }
   

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -56,7 +56,15 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   WrenReallocateFn reallocate = defaultReallocate;
   void* userData = NULL;
   if (config != NULL) {
-    reallocate = config->reallocateFn;
+    
+    // ensure config has a reallocate function
+    if (config->reallocateFn != NULL) {
+      reallocate = config->reallocateFn;
+    }
+    else {
+      config->reallocateFn = defaultReallocate;
+    }
+
     userData = config->userData;
   }
   

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -56,13 +56,7 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   WrenReallocateFn reallocate = defaultReallocate;
   void* userData = NULL;
   if (config != NULL) {
-    
-    // ensure config has a reallocate function
-    if (config->reallocateFn == NULL) {
-      config->reallocateFn = defaultReallocate;
-    }
-
-    reallocate = config->reallocateFn;
+    reallocate = config->reallocateFn ? config->reallocateFn : defaultReallocate;
     userData = config->userData;
   }
   
@@ -73,6 +67,7 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   if (config != NULL)
   {
     memcpy(&vm->config, config, sizeof(WrenConfiguration));
+    vm->config.reallocateFn = reallocate;
   }
   else
   {

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -56,8 +56,8 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   WrenReallocateFn reallocate = defaultReallocate;
   void* userData = NULL;
   if (config != NULL) {
-    reallocate = config->reallocateFn ? config->reallocateFn : defaultReallocate;
     userData = config->userData;
+    reallocate = config->reallocateFn ? config->reallocateFn : defaultReallocate;
   }
   
   WrenVM* vm = (WrenVM*)reallocate(NULL, sizeof(*vm), userData);
@@ -67,6 +67,9 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   if (config != NULL)
   {
     memcpy(&vm->config, config, sizeof(WrenConfiguration));
+
+    // We choose to set this after copying, 
+    // rather than modifying the user config pointer
     vm->config.reallocateFn = reallocate;
   }
   else


### PR DESCRIPTION
currently you cant provide a config without also providing a `reallocateFn`. Most cases `reallocateFn` gets filled by `wrenInitConfiguration`. This just ensure a reallocate function always exists