### PR TITLE
Add an additional escape sequence \e.

### DIFF
--- a/doc/site/values.markdown
+++ b/doc/site/values.markdown
@@ -69,6 +69,7 @@ A handful of escape characters are supported:
 "\%" // A percent sign.
 "\a" // Alarm beep. (Who uses this?)
 "\b" // Backspace.
+"\e" // ESC character.
 "\f" // Formfeed.
 "\n" // Newline.
 "\r" // Carriage return.

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -972,6 +972,7 @@ static void readString(Parser* parser)
         case '0':  wrenByteBufferWrite(parser->vm, &string, '\0'); break;
         case 'a':  wrenByteBufferWrite(parser->vm, &string, '\a'); break;
         case 'b':  wrenByteBufferWrite(parser->vm, &string, '\b'); break;
+        case 'e':  wrenByteBufferWrite(parser->vm, &string, '\33'); break;
         case 'f':  wrenByteBufferWrite(parser->vm, &string, '\f'); break;
         case 'n':  wrenByteBufferWrite(parser->vm, &string, '\n'); break;
         case 'r':  wrenByteBufferWrite(parser->vm, &string, '\r'); break;


### PR DESCRIPTION
This is an idea I had when discussing #945 to avoid the need to support octal escape sequences.

Probably, the only common use for these nowadays is to encode the ESC character (0o33) itself in ANSI escape codes and adding an escape sequence for this will make life a little easier.

It's not a new idea as gcc, clang and tcc already support it as a non-standard extension to their C compilers.

I haven't added a test as the other escape sequences which represent control characters don't seem to have any.