### PR TITLE
Experimental - multiple return values

### DIFF
--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -546,4 +546,7 @@ WREN_API void* wrenGetUserData(WrenVM* vm);
 // Sets user data associated with the WrenVM.
 WREN_API void wrenSetUserData(WrenVM* vm, void* userData);
 
+// Sets how many values are returned from a foreign call.
+void wrenSetForeignReturnValues(WrenVM* vm, int num);
+
 #endif

--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -106,6 +106,9 @@
 // is so that error messages mentioning variables can be stack allocated.
 #define MAX_VARIABLE_NAME 64
 
+// The maximum number of return values allowed from a method.
+#define MAX_RETURN_VALUES 8
+
 // The maximum number of fields a class can have, including inherited fields.
 // This is explicit in the bytecode since `CODE_CLASS` and `CODE_SUBCLASS` take
 // a single byte for the number of fields. Note that it's 255 and not 256

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3544,7 +3544,8 @@ static void variableDefinition(Compiler* compiler)
   int numVars = 0;
   do
   {
-    if (numVars >= MAX_RETURN_VALUES) {
+    if (numVars >= MAX_RETURN_VALUES) 
+    {
       error(compiler, "Too many variable declarations, only %d supported.", MAX_RETURN_VALUES);
       break;
     }
@@ -3559,9 +3560,16 @@ static void variableDefinition(Compiler* compiler)
     ignoreNewlines(compiler);
     // support multiple assignments, these don't have to match nr of variables above
     // because each expression can leave multiple values on the stack.
+    int values = 0;
     do
     {
       expression(compiler);
+      if (++values > numVars) 
+      {
+        // we can now be sure that we have too many values
+        error(compiler, "Too many values in variable declaration, expect max %d.", numVars);
+        break;
+      }
     } while (match(compiler, TOKEN_COMMA));
   }
   else

--- a/src/vm/wren_opcodes.h
+++ b/src/vm/wren_opcodes.h
@@ -141,6 +141,10 @@ OPCODE(CLOSE_UPVALUE, -1)
 // stack.
 OPCODE(RETURN, 0)
 
+// Exit from the current function and return several values on the top of
+// the stack.
+OPCODE(RETURN_MULTIPLE, 0)
+
 // Creates a closure for the function stored at [arg] in the constant table.
 //
 // Following the function argument is a number of arguments, two for each

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -381,12 +381,13 @@ static void callForeign(WrenVM* vm, ObjFiber* fiber,
 {
   ASSERT(vm->apiStack == NULL, "Cannot already be in foreign call.");
   vm->apiStack = fiber->stackTop - numArgs;
+  vm->numForeignReturnValues = 1;
 
   foreign(vm);
 
   // Discard the stack slots for the arguments and temporaries but leave one
   // for the result.
-  fiber->stackTop = vm->apiStack + 1;
+  fiber->stackTop = vm->apiStack + vm->numForeignReturnValues;
 
   vm->apiStack = NULL;
 }
@@ -1188,13 +1189,12 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
 
     CASE_CODE(RETURN):
     {
-      Value result = POP();
-      fiber->numFrames--;
-
+    normalReturn:
       // Close any upvalues still in scope.
       closeUpvalues(fiber, stackStart);
 
       // If the fiber is complete, end it.
+      fiber->numFrames--;
       if (fiber->numFrames == 0)
       {
         // See if there's another fiber to return to. If not, we're done.
@@ -1202,30 +1202,58 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
         {
           // Store the final result value at the beginning of the stack so the
           // C API can get it.
-          fiber->stack[0] = result;
+          fiber->stack[0] = PEEK();
           fiber->stackTop = fiber->stack + 1;
           return WREN_RESULT_SUCCESS;
         }
-        
+
+        Value result = PEEK();
         ObjFiber* resumingFiber = fiber->caller;
         fiber->caller = NULL;
         fiber = resumingFiber;
         vm->fiber = resumingFiber;
-        
+
         // Store the result in the resuming fiber.
         fiber->stackTop[-1] = result;
       }
       else
       {
         // Store the result of the block in the first slot, which is where the
-        // caller expects it.
-        stackStart[0] = result;
+        // caller expects it. Use PEEK() since stackTop is written to in the 
+        // next statement.
+        frame->stackStart[0] = PEEK();
 
         // Discard the stack slots for the call frame (leaving one slot for the
         // result).
         fiber->stackTop = frame->stackStart + 1;
       }
-      
+
+      LOAD_FRAME();
+      DISPATCH();
+    }
+
+    CASE_CODE(RETURN_MULTIPLE):
+    {
+      if (fiber->numFrames == 1)
+      {
+        // Don't allow fiber exits with multiple return values
+        // (for performance reasons.)
+        READ_BYTE();
+        goto normalReturn;
+      }
+      fiber->numFrames--;
+
+      // Close any upvalues still in scope.
+      closeUpvalues(fiber, stackStart);
+
+      // Move return values on stack to be in correct place
+      const int numReturnValues = READ_BYTE();
+      for (int i = 0; i < numReturnValues; i++)
+      {
+        stackStart[i] = fiber->stackTop[i - numReturnValues];
+      }
+      fiber->stackTop = frame->stackStart + numReturnValues;
+
       LOAD_FRAME();
       DISPATCH();
     }
@@ -1954,4 +1982,10 @@ void* wrenGetUserData(WrenVM* vm)
 void wrenSetUserData(WrenVM* vm, void* userData)
 {
 	vm->config.userData = userData;
+}
+
+void wrenSetForeignReturnValues(WrenVM* vm, int num)
+{
+  ASSERT(num > 0, "Number of foreign return values must be zero or larger.");
+  vm->numForeignReturnValues = num;
 }

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -99,6 +99,9 @@ struct WrenVM
   // initialized.
   Value* apiStack;
 
+  // Set during foreign calls to indicate multiple return values
+  int numForeignReturnValues;
+
   WrenConfiguration config;
   
   // Compiler and debugger data:

--- a/test/api/api_tests.c
+++ b/test/api/api_tests.c
@@ -55,6 +55,9 @@ WrenForeignMethodFn APITest_bindForeignMethod(
   method = userDataBindMethod(fullName);
   if (method != NULL) return method;
 
+  method = multipleReturnValuesForeignBindMethod(fullName);
+  if (method != NULL) return method;
+
   fprintf(stderr,
       "Unknown foreign method '%s' for test '%s'\n", fullName, testName);
   exit(1);

--- a/test/api/api_tests.h
+++ b/test/api/api_tests.h
@@ -23,6 +23,7 @@
 #include "resolution.h"
 #include "slots.h"
 #include "user_data.h"
+#include "multiple_return_values_foreign.h"
 
 int APITest_Run(WrenVM* vm, const char* inTestName);
 

--- a/test/api/multiple_return_values_foreign.c
+++ b/test/api/multiple_return_values_foreign.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "wren.h"
+
+static void values(WrenVM *vm) {
+  wrenSetForeignReturnValues(vm, 4);
+  wrenEnsureSlots(vm, 4);
+  wrenSetSlotDouble(vm, 0, 1);       // slot, value
+  wrenSetSlotDouble(vm, 1, 2);
+  wrenSetSlotDouble(vm, 2, 3);
+  wrenSetSlotDouble(vm, 3, 4);
+}
+
+WrenForeignMethodFn multipleReturnValuesForeignBindMethod(const char* signature)
+{
+  if (strcmp(signature, "static MultipleReturnValuesForeign.values()") == 0) return values;
+
+  return NULL;
+}

--- a/test/api/multiple_return_values_foreign.h
+++ b/test/api/multiple_return_values_foreign.h
@@ -1,0 +1,3 @@
+#include "wren.h"
+
+WrenForeignMethodFn multipleReturnValuesForeignBindMethod(const char* signature);

--- a/test/api/multiple_return_values_foreign.wren
+++ b/test/api/multiple_return_values_foreign.wren
@@ -1,0 +1,20 @@
+
+class MultipleReturnValuesForeign {
+  foreign static values()
+
+  static local_values() {
+    var v1, v2, v3, v4 = values()
+    System.print(v1.toString) // expect: 1
+    System.print(v2.toString) // expect: 2
+    System.print(v3.toString) // expect: 3
+    System.print(v4.toString) // expect: 4
+  }
+}
+
+MultipleReturnValuesForeign.local_values()
+
+var v1, v2, v3, v4 = MultipleReturnValuesForeign.values()
+System.print(v1.toString) // expect: 1
+System.print(v2.toString) // expect: 2
+System.print(v3.toString) // expect: 3
+System.print(v4.toString) // expect: 4

--- a/test/language/assignment/multiple.wren
+++ b/test/language/assignment/multiple.wren
@@ -1,0 +1,85 @@
+
+class Foo {
+  static four_values {
+      return 1, 2, 3, 4
+  }
+
+  static one_value {
+      return four_values
+  }
+}
+
+Fn.new {
+  var v1, v2, v3, v4, v5, v6, v7, v8 = 1, 2, 1+2, 4, 3+2, 6, 8-1, 4+4
+  System.print(v1.toString) // expect: 1
+  System.print(v2.toString) // expect: 2
+  System.print(v3.toString) // expect: 3
+  System.print(v4.toString) // expect: 4
+  System.print(v5.toString) // expect: 5
+  System.print(v6.toString) // expect: 6
+  System.print(v7.toString) // expect: 7
+  System.print(v8.toString) // expect: 8
+
+  var a1, a2, a3, a4, a5 = Foo.four_values, 5
+  System.print(a1.toString) // expect: 1
+  System.print(a2.toString) // expect: 2
+  System.print(a3.toString) // expect: 3
+  System.print(a4.toString) // expect: 4
+  System.print(a5.toString) // expect: 5
+
+  // too many values will leave extra elements on stack
+  var x1, x2, x3, x4 = Foo.four_values, 5
+  System.print(x1.toString) // expect: 1
+  System.print(x2.toString) // expect: 2
+  System.print(x3.toString) // expect: 3
+  System.print(x4.toString) // expect: 4
+
+  // stack position is now out of sync
+  var y1 = 1
+  System.print(y1.toString) // expect: 5
+
+  // still out of sync here, but will reset on function return
+
+}.call()
+
+Fn.new {
+  // too few values will lead to undefined values
+  var z1, z2, z3, z4 = 1, 2, 3
+  System.print(z1.toString) // expect: 1
+  System.print(z2.toString) // expect: 2
+  System.print(z3.toString) // expect: 3
+  //System.print(z4.toString) // undefined
+}.call()
+
+// module variables
+var v1, v2, v3, v4, v5 = 5, 4, 3, 2, 1
+System.print(v1.toString) // expect: 5
+System.print(v2.toString) // expect: 4
+System.print(v3.toString) // expect: 3
+System.print(v4.toString) // expect: 2
+System.print(v5.toString) // expect: 1
+
+var a1, a2, a3, a4, a5 = Foo.four_values, 5
+System.print(a1.toString) // expect: 1
+System.print(a2.toString) // expect: 2
+System.print(a3.toString) // expect: 3
+System.print(a4.toString) // expect: 4
+System.print(a5.toString) // expect: 5
+
+// chained returns will not forward multiple returns
+var o1 = Foo.one_value
+System.print(o1.toString) // expect: 4
+
+// too many values will lead to incorrect stack pop
+var x1, x2, x3, x4 = Foo.four_values, 5
+System.print(x1.toString) // expect: 2
+System.print(x2.toString) // expect: 3
+System.print(x3.toString) // expect: 4
+System.print(x4.toString) // expect: 5
+
+// too few values will lead to incorrect stack pop
+var z1, z2, z3, z4 = 1, 2, 3
+//System.print(z1.toString) // undefined
+System.print(z2.toString) // expect: 1
+System.print(z3.toString) // expect: 2
+System.print(z4.toString) // expect: 3

--- a/test/language/return/multiple_return_local.wren
+++ b/test/language/return/multiple_return_local.wren
@@ -1,0 +1,17 @@
+class Foo {
+  construct new() {}
+
+  method {
+    return "one", "two", "three"
+    System.print("bad")
+  }
+
+  local_values() {
+    var v1, v2, v3 = method
+    System.print(v1) // expect: one
+    System.print(v2) // expect: two
+    System.print(v3) // expect: three
+  }
+}
+
+Foo.new().local_values()

--- a/test/language/return/multiple_return_module.wren
+++ b/test/language/return/multiple_return_module.wren
@@ -1,0 +1,13 @@
+class Foo {
+  construct new() {}
+
+  method {
+    return "one", "two", "three"
+    System.print("bad")
+  }
+}
+
+var v1, v2, v3 = Foo.new().method
+System.print(v1) // expect: one
+System.print(v2) // expect: two
+System.print(v3) // expect: three


### PR DESCRIPTION

Adds supports for multiple return values from foreign and wren methods. It does this by adding a new OPCODE for multiple return values, the thinking is that most returns will use the existing OPCODE and remain unchanged. The opcode is not needed for foreign return values.

This PR can probably not be merged as is, but I've been using something like this in my own game engine. It works, but is missing stack corruption checks. This is maybe too fragile for general consumption? The problem is added stack corruption checks without affecting performance. One way to add static checks might be to allow functions to declare how many return values they have.

Anyways, I figured I would share my code to show how an implementation might work. 

There are no performance changes (<2%) with these commits. (On my Ryzen 3900X and M1 mac, might need more testing.) But I cheated a little bit by tweaking the normal return op code path with some optimizations.
