### PR TITLE
Give foreign methods a userData field

### DIFF
--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -58,7 +58,7 @@ typedef struct WrenHandle WrenHandle;
 typedef void* (*WrenReallocateFn)(void* memory, size_t newSize, void* userData);
 
 // A function callable from Wren code, but implemented in C.
-typedef void (*WrenForeignMethodFn)(WrenVM* vm);
+typedef void (*WrenForeignMethodFn)(WrenVM* vm, void *userData);
 
 // A finalizer function for freeing resources owned by an instance of a foreign
 // class. Unlike most foreign methods, finalizers do not have access to the VM
@@ -93,9 +93,19 @@ typedef struct WrenLoadModuleResult
 // Loads and returns the source code for the module [name].
 typedef WrenLoadModuleResult (*WrenLoadModuleFn)(WrenVM* vm, const char* name);
 
-// Returns a pointer to a foreign method on [className] in [module] with
-// [signature].
-typedef WrenForeignMethodFn (*WrenBindForeignMethodFn)(WrenVM* vm,
+// The result of a bindForeignMethodFn call.
+// [executeFn] is the function to call.
+// [userData] is passed to [executeFn].  The caller is responsible for making
+// sure [userData] is still valid whenever Wren calls [executeFn].
+typedef struct WrenBindForeignMethodResult {
+  WrenForeignMethodFn executeFn;
+  void* userData;
+} WrenBindForeignMethodResult;
+
+// Returns a foreign method and userdata on [className] in [module]
+// with [isStatic]/[signature].  If the method is not found, the returned
+// WrenBindForeignMethodResult.executeFn == NULL.
+typedef WrenBindForeignMethodResult (*WrenBindForeignMethodFn)(WrenVM* vm,
     const char* module, const char* className, bool isStatic,
     const char* signature);
 

--- a/src/optional/wren_opt_meta.c
+++ b/src/optional/wren_opt_meta.c
@@ -7,7 +7,7 @@
 #include "wren_vm.h"
 #include "wren_opt_meta.wren.inc"
 
-void metaCompile(WrenVM* vm)
+void metaCompile(WrenVM* vm, void* userData)
 {
   const char* source = wrenGetSlotString(vm, 1);
   bool isExpression = wrenGetSlotBool(vm, 2);
@@ -37,7 +37,7 @@ void metaCompile(WrenVM* vm)
   }
 }
 
-void metaGetModuleVariables(WrenVM* vm)
+void metaGetModuleVariables(WrenVM* vm, void* userData)
 {
   wrenEnsureSlots(vm, 3);
   
@@ -70,27 +70,29 @@ const char* wrenMetaSource()
   return metaModuleSource;
 }
 
-WrenForeignMethodFn wrenMetaBindForeignMethod(WrenVM* vm,
+WrenBindForeignMethodResult wrenMetaBindForeignMethod(WrenVM* vm,
                                               const char* className,
                                               bool isStatic,
                                               const char* signature)
 {
+  WrenBindForeignMethodResult result = {0};
+
   // There is only one foreign method in the meta module.
   ASSERT(strcmp(className, "Meta") == 0, "Should be in Meta class.");
   ASSERT(isStatic, "Should be static.");
-  
+
   if (strcmp(signature, "compile_(_,_,_)") == 0)
   {
-    return metaCompile;
+    result.executeFn = metaCompile;
   }
-  
-  if (strcmp(signature, "getModuleVariables_(_)") == 0)
+
+  else if (strcmp(signature, "getModuleVariables_(_)") == 0)
   {
-    return metaGetModuleVariables;
+    result.executeFn = metaGetModuleVariables;
   }
-  
-  ASSERT(false, "Unknown method.");
-  return NULL;
+
+  ASSERT(result.executeFn != NULL, "Unknown method.");
+  return result;
 }
 
 #endif

--- a/src/optional/wren_opt_meta.h
+++ b/src/optional/wren_opt_meta.h
@@ -8,7 +8,7 @@
 #if WREN_OPT_META
 
 const char* wrenMetaSource();
-WrenForeignMethodFn wrenMetaBindForeignMethod(WrenVM* vm,
+WrenBindForeignMethodResult wrenMetaBindForeignMethod(WrenVM* vm,
                                               const char* className,
                                               bool isStatic,
                                               const char* signature);

--- a/src/optional/wren_opt_random.c
+++ b/src/optional/wren_opt_random.c
@@ -37,13 +37,13 @@ static uint32_t advanceState(Well512* well)
   return well->state[well->index];
 }
 
-static void randomAllocate(WrenVM* vm)
+static void randomAllocate(WrenVM* vm, void* userData)
 {
   Well512* well = (Well512*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(Well512));
   well->index = 0;
 }
 
-static void randomSeed0(WrenVM* vm)
+static void randomSeed0(WrenVM* vm, void* userData)
 {
   Well512* well = (Well512*)wrenGetSlotForeign(vm, 0);
 
@@ -54,7 +54,7 @@ static void randomSeed0(WrenVM* vm)
   }
 }
 
-static void randomSeed1(WrenVM* vm)
+static void randomSeed1(WrenVM* vm, void* userData)
 {
   Well512* well = (Well512*)wrenGetSlotForeign(vm, 0);
 
@@ -65,7 +65,7 @@ static void randomSeed1(WrenVM* vm)
   }
 }
 
-static void randomSeed16(WrenVM* vm)
+static void randomSeed16(WrenVM* vm, void* userData)
 {
   Well512* well = (Well512*)wrenGetSlotForeign(vm, 0);
 
@@ -75,7 +75,7 @@ static void randomSeed16(WrenVM* vm)
   }
 }
 
-static void randomFloat(WrenVM* vm)
+static void randomFloat(WrenVM* vm, void* userData)
 {
   Well512* well = (Well512*)wrenGetSlotForeign(vm, 0);
 
@@ -95,7 +95,7 @@ static void randomFloat(WrenVM* vm)
   wrenSetSlotDouble(vm, 0, result);
 }
 
-static void randomInt0(WrenVM* vm)
+static void randomInt0(WrenVM* vm, void* userData)
 {
   Well512* well = (Well512*)wrenGetSlotForeign(vm, 0);
 
@@ -118,27 +118,28 @@ WrenForeignClassMethods wrenRandomBindForeignClass(WrenVM* vm,
   return methods;
 }
 
-WrenForeignMethodFn wrenRandomBindForeignMethod(WrenVM* vm,
+WrenBindForeignMethodResult wrenRandomBindForeignMethod(WrenVM* vm,
                                                 const char* className,
                                                 bool isStatic,
                                                 const char* signature)
 {
+  WrenBindForeignMethodResult result = {0};
   ASSERT(strcmp(className, "Random") == 0, "Should be in Random class.");
-  
-  if (strcmp(signature, "<allocate>") == 0) return randomAllocate;
-  if (strcmp(signature, "seed_()") == 0) return randomSeed0;
-  if (strcmp(signature, "seed_(_)") == 0) return randomSeed1;
-  
-  if (strcmp(signature, "seed_(_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)") == 0)
+
+  if (strcmp(signature, "<allocate>") == 0) result.executeFn = randomAllocate;
+  else if (strcmp(signature, "seed_()") == 0) result.executeFn = randomSeed0;
+  else if (strcmp(signature, "seed_(_)") == 0) result.executeFn = randomSeed1;
+
+  else if (strcmp(signature, "seed_(_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_)") == 0)
   {
-    return randomSeed16;
+    result.executeFn =  randomSeed16;
   }
-  
-  if (strcmp(signature, "float()") == 0) return randomFloat;
-  if (strcmp(signature, "int()") == 0) return randomInt0;
-  
-  ASSERT(false, "Unknown method.");
-  return NULL;
+
+  else if (strcmp(signature, "float()") == 0) result.executeFn = randomFloat;
+  else if (strcmp(signature, "int()") == 0) result.executeFn = randomInt0;
+
+  ASSERT(result.executeFn != NULL, "Unknown method.");
+  return result;
 }
 
 #endif

--- a/src/optional/wren_opt_random.h
+++ b/src/optional/wren_opt_random.h
@@ -10,7 +10,7 @@ const char* wrenRandomSource();
 WrenForeignClassMethods wrenRandomBindForeignClass(WrenVM* vm,
                                                    const char* module,
                                                    const char* className);
-WrenForeignMethodFn wrenRandomBindForeignMethod(WrenVM* vm,
+WrenBindForeignMethodResult wrenRandomBindForeignMethod(WrenVM* vm,
                                                 const char* className,
                                                 bool isStatic,
                                                 const char* signature);

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -377,6 +377,9 @@ typedef struct
 {
   MethodType type;
 
+  // Userdata for foreign methods
+  void *userData;
+
   // The method function itself. The [type] determines which field of the union
   // is used.
   union

--- a/test/api/api_tests.c
+++ b/test/api/api_tests.c
@@ -2,11 +2,19 @@
 
 static const char* testName = NULL;
 
-WrenForeignMethodFn APITest_bindForeignMethod(
+WrenBindForeignMethodResult APITest_bindForeignMethod(
     WrenVM* vm, const char* module, const char* className,
     bool isStatic, const char* signature)
 {
-  if (strncmp(module, "./test/", 7) != 0) return NULL;
+#define RETURN_IF_NONNULL(m) \
+  do { if (method != NULL) { \
+    result.executeFn = method; \
+    return result; \
+  } } while(0)
+
+  WrenBindForeignMethodResult result = {0};
+
+  if (strncmp(module, "./test/", 7) != 0) return result;
 
   // For convenience, concatenate all of the method qualifiers into a single
   // signature string.
@@ -20,45 +28,46 @@ WrenForeignMethodFn APITest_bindForeignMethod(
   WrenForeignMethodFn method = NULL;
 
   method = benchmarkBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = callCallsForeignBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = errorBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = getVariableBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = foreignClassBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = handleBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = listsBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = mapsBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = newVMBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = resolutionBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = slotsBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   method = userDataBindMethod(fullName);
-  if (method != NULL) return method;
+  RETURN_IF_NONNULL(method);
 
   fprintf(stderr,
       "Unknown foreign method '%s' for test '%s'\n", fullName, testName);
   exit(1);
-  return NULL;
+  return result;
+#undef RETURN_IF_NONNULL
 }
 
 WrenForeignClassMethods APITest_bindForeignClass(

--- a/test/api/api_tests.h
+++ b/test/api/api_tests.h
@@ -26,7 +26,7 @@
 
 int APITest_Run(WrenVM* vm, const char* inTestName);
 
-WrenForeignMethodFn APITest_bindForeignMethod(
+WrenBindForeignMethodResult APITest_bindForeignMethod(
     WrenVM* vm, const char* module, const char* className,
     bool isStatic, const char* signature);
 

--- a/test/api/benchmark.c
+++ b/test/api/benchmark.c
@@ -3,7 +3,7 @@
 
 #include "benchmark.h"
 
-static void arguments(WrenVM* vm)
+static void arguments(WrenVM* vm, void *userData)
 {
   double result = 0;
 
@@ -20,7 +20,7 @@ const char* testScript =
 "  static method(a, b, c, d) { a + b + c + d }\n"
 "}\n";
 
-static void call(WrenVM* vm)
+static void call(WrenVM* vm, void *userData)
 {
   int iterations = (int)wrenGetSlotDouble(vm, 1);
 

--- a/test/api/call_calls_foreign.c
+++ b/test/api/call_calls_foreign.c
@@ -3,7 +3,7 @@
 
 #include "wren.h"
 
-static void api(WrenVM *vm) {
+static void api(WrenVM *vm, void *userData) {
   // Grow the slot array. This should trigger the stack to be moved.
   wrenEnsureSlots(vm, 10);
   wrenSetSlotNewList(vm, 0);

--- a/test/api/error.c
+++ b/test/api/error.c
@@ -3,7 +3,7 @@
 
 #include "error.h"
 
-static void runtimeError(WrenVM* vm)
+static void runtimeError(WrenVM* vm, void *userData)
 {
   wrenEnsureSlots(vm, 1);
   wrenSetSlotString(vm, 0, "Error!");

--- a/test/api/foreign_class.c
+++ b/test/api/foreign_class.c
@@ -5,18 +5,18 @@
 
 static int finalized = 0;
 
-static void apiFinalized(WrenVM* vm)
+static void apiFinalized(WrenVM* vm, void *userData)
 {
   wrenSetSlotDouble(vm, 0, finalized);
 }
 
-static void counterAllocate(WrenVM* vm)
+static void counterAllocate(WrenVM* vm, void *userData)
 {
   double* value = (double*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(double));
   *value = 0;
 }
 
-static void counterIncrement(WrenVM* vm)
+static void counterIncrement(WrenVM* vm, void *userData)
 {
   double* value = (double*)wrenGetSlotForeign(vm, 0);
   double increment = wrenGetSlotDouble(vm, 1);
@@ -24,13 +24,13 @@ static void counterIncrement(WrenVM* vm)
   *value += increment;
 }
 
-static void counterValue(WrenVM* vm)
+static void counterValue(WrenVM* vm, void *userData)
 {
   double value = *(double*)wrenGetSlotForeign(vm, 0);
   wrenSetSlotDouble(vm, 0, value);
 }
 
-static void pointAllocate(WrenVM* vm)
+static void pointAllocate(WrenVM* vm, void *userData)
 {
   double* coordinates = (double*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(double[3]));
 
@@ -50,7 +50,7 @@ static void pointAllocate(WrenVM* vm)
   }
 }
 
-static void pointTranslate(WrenVM* vm)
+static void pointTranslate(WrenVM* vm, void *userData)
 {
   double* coordinates = (double*)wrenGetSlotForeign(vm, 0);
   coordinates[0] += wrenGetSlotDouble(vm, 1);
@@ -58,7 +58,7 @@ static void pointTranslate(WrenVM* vm)
   coordinates[2] += wrenGetSlotDouble(vm, 3);
 }
 
-static void pointToString(WrenVM* vm)
+static void pointToString(WrenVM* vm, void *userData)
 {
   double* coordinates = (double*)wrenGetSlotForeign(vm, 0);
   char result[100];
@@ -67,7 +67,7 @@ static void pointToString(WrenVM* vm)
   wrenSetSlotString(vm, 0, result);
 }
 
-static void resourceAllocate(WrenVM* vm)
+static void resourceAllocate(WrenVM* vm, void *userData)
 {
   int* value = (int*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(int));
   *value = 123;
@@ -82,7 +82,7 @@ static void resourceFinalize(void* data)
   finalized++;
 }
 
-static void badClassAllocate(WrenVM* vm)
+static void badClassAllocate(WrenVM* vm, void *userData)
 {
   wrenEnsureSlots(vm, 1);
   wrenSetSlotString(vm, 0, "Something went wrong");

--- a/test/api/get_variable.c
+++ b/test/api/get_variable.c
@@ -2,22 +2,22 @@
 
 #include "get_variable.h"
 
-static void beforeDefined(WrenVM* vm)
+static void beforeDefined(WrenVM* vm, void *userData)
 {
   wrenGetVariable(vm, "./test/api/get_variable", "A", 0);
 }
 
-static void afterDefined(WrenVM* vm)
+static void afterDefined(WrenVM* vm, void *userData)
 {
   wrenGetVariable(vm, "./test/api/get_variable", "A", 0);
 }
 
-static void afterAssigned(WrenVM* vm)
+static void afterAssigned(WrenVM* vm, void *userData)
 {
   wrenGetVariable(vm, "./test/api/get_variable", "A", 0);
 }
 
-static void otherSlot(WrenVM* vm)
+static void otherSlot(WrenVM* vm, void *userData)
 {
   wrenEnsureSlots(vm, 3);
   wrenGetVariable(vm, "./test/api/get_variable", "B", 2);
@@ -27,12 +27,12 @@ static void otherSlot(WrenVM* vm)
   wrenSetSlotString(vm, 0, string);
 }
 
-static void otherModule(WrenVM* vm)
+static void otherModule(WrenVM* vm, void *userData)
 {
   wrenGetVariable(vm, "./test/api/get_variable_module", "Variable", 0);
 }
 
-static void hasVariable(WrenVM* vm)
+static void hasVariable(WrenVM* vm, void *userData)
 {
   const char* module = wrenGetSlotString(vm, 1);
   const char* variable = wrenGetSlotString(vm, 2);
@@ -42,7 +42,7 @@ static void hasVariable(WrenVM* vm)
   wrenSetSlotBool(vm, 0, result);
 }
 
-static void hasModule(WrenVM* vm)
+static void hasModule(WrenVM* vm, void *userData)
 {
   const char* module = wrenGetSlotString(vm, 1);
 

--- a/test/api/handle.c
+++ b/test/api/handle.c
@@ -4,12 +4,12 @@
 
 static WrenHandle* handle;
 
-static void setValue(WrenVM* vm)
+static void setValue(WrenVM* vm, void *userData)
 {
   handle = wrenGetSlotHandle(vm, 1);
 }
 
-static void getValue(WrenVM* vm)
+static void getValue(WrenVM* vm, void *userData)
 {
   wrenSetSlotHandle(vm, 0, handle);
   wrenReleaseHandle(vm, handle);

--- a/test/api/lists.c
+++ b/test/api/lists.c
@@ -2,7 +2,7 @@
 
 #include "lists.h"
 
-static void newList(WrenVM* vm)
+static void newList(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewList(vm, 0);
 }
@@ -23,7 +23,7 @@ static void appendNumber(WrenVM* vm, double value)
   wrenInsertInList(vm, 0, -1, 1);
 }
 
-static void insert(WrenVM* vm)
+static void insert(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewList(vm, 0);
 
@@ -45,7 +45,7 @@ static void insert(WrenVM* vm)
   insertNumber(vm, -3, 9.0);
 }
 
-static void get(WrenVM* vm)
+static void get(WrenVM* vm, void *userData)
 {
   int listSlot = 1;
   int index = (int)wrenGetSlotDouble(vm, 2);
@@ -53,7 +53,7 @@ static void get(WrenVM* vm)
   wrenGetListElement(vm, listSlot, index, 0);
 }
 
-static void set(WrenVM* vm)
+static void set(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewList(vm, 0);
 

--- a/test/api/maps.c
+++ b/test/api/maps.c
@@ -2,12 +2,12 @@
 
 #include "maps.h"
 
-static void newMap(WrenVM* vm)
+static void newMap(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewMap(vm, 0);
 }
 
-static void invalidInsert(WrenVM* vm)
+static void invalidInsert(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewMap(vm, 0);
   
@@ -17,7 +17,7 @@ static void invalidInsert(WrenVM* vm)
   wrenSetMapValue(vm, 0, 1, 2); // expect this to cause errors
 }
 
-static void insert(WrenVM* vm)
+static void insert(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewMap(vm, 0);
   
@@ -49,7 +49,7 @@ static void insert(WrenVM* vm)
   wrenSetMapValue(vm, 0, 1, 2);
 }
 
-static void removeKey(WrenVM* vm)
+static void removeKey(WrenVM* vm, void *userData)
 {
   wrenEnsureSlots(vm, 3);
 
@@ -57,29 +57,29 @@ static void removeKey(WrenVM* vm)
   wrenRemoveMapValue(vm, 1, 2, 0);
 }
 
-static void countWren(WrenVM* vm)
+static void countWren(WrenVM* vm, void *userData)
 {
   int count = wrenGetMapCount(vm, 1);
   wrenSetSlotDouble(vm, 0, count);
 }
 
-static void countAPI(WrenVM* vm)
+static void countAPI(WrenVM* vm, void *userData)
 {
-  insert(vm);
+  insert(vm, userData);
   int count = wrenGetMapCount(vm, 0);
   wrenSetSlotDouble(vm, 0, count);
 }
 
-static void containsWren(WrenVM* vm)
+static void containsWren(WrenVM* vm, void *userData)
 {
   bool result = wrenGetMapContainsKey(vm, 1, 2);
   wrenSetSlotBool(vm, 0, result);
 }
 
 
-static void containsAPI(WrenVM* vm)
+static void containsAPI(WrenVM* vm, void *userData)
 {
-  insert(vm);
+  insert(vm, userData);
   
   wrenEnsureSlots(vm, 1);
   wrenSetSlotString(vm, 1, "England");
@@ -88,9 +88,9 @@ static void containsAPI(WrenVM* vm)
   wrenSetSlotBool(vm, 0, result);
 }
 
-static void containsAPIFalse(WrenVM* vm)
+static void containsAPIFalse(WrenVM* vm, void *userData)
 {
-  insert(vm);
+  insert(vm, userData);
 
   wrenEnsureSlots(vm, 1);
   wrenSetSlotString(vm, 1, "DefinitelyNotARealKey");
@@ -115,7 +115,7 @@ WrenForeignMethodFn mapsBindMethod(const char* signature)
   return NULL;
 }
 
-void foreignAllocate(WrenVM* vm) {
+void foreignAllocate(WrenVM* vm, void *userData) {
   wrenSetSlotNewForeign(vm, 0, 0, 0);
 }
 

--- a/test/api/new_vm.c
+++ b/test/api/new_vm.c
@@ -2,7 +2,7 @@
 
 #include "new_vm.h"
 
-static void nullConfig(WrenVM* vm)
+static void nullConfig(WrenVM* vm, void *userData)
 {
   WrenVM* otherVM = wrenNewVM(NULL);
 
@@ -13,7 +13,7 @@ static void nullConfig(WrenVM* vm)
   wrenFreeVM(otherVM);
 }
 
-static void multipleInterpretCalls(WrenVM* vm)
+static void multipleInterpretCalls(WrenVM* vm, void *userData)
 {
   WrenVM* otherVM = wrenNewVM(NULL);
   WrenInterpretResult result;

--- a/test/api/reset_stack_after_foreign_construct.c
+++ b/test/api/reset_stack_after_foreign_construct.c
@@ -3,7 +3,7 @@
 
 #include "wren.h"
 
-static void counterAllocate(WrenVM* vm)
+static void counterAllocate(WrenVM* vm, void *userData)
 {
   double* counter = (double*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(double));
   *counter = wrenGetSlotDouble(vm, 1);

--- a/test/api/resolution.c
+++ b/test/api/resolution.c
@@ -65,7 +65,7 @@ static void runTestVM(WrenVM* vm, WrenConfiguration* configuration,
   wrenFreeVM(otherVM);
 }
 
-static void noResolver(WrenVM* vm)
+static void noResolver(WrenVM* vm, void *userData)
 {
   WrenConfiguration configuration;
   wrenInitConfiguration(&configuration);
@@ -86,7 +86,7 @@ static const char* resolveToNull(WrenVM* vm, const char* importer,
   return NULL;
 }
 
-static void returnsNull(WrenVM* vm)
+static void returnsNull(WrenVM* vm, void *userData)
 {
   WrenConfiguration configuration;
   wrenInitConfiguration(&configuration);
@@ -114,7 +114,7 @@ static const char* resolveChange(WrenVM* vm, const char* importer,
   return result;
 }
 
-static void changesString(WrenVM* vm)
+static void changesString(WrenVM* vm, void *userData)
 {
   WrenConfiguration configuration;
   wrenInitConfiguration(&configuration);
@@ -123,7 +123,7 @@ static void changesString(WrenVM* vm)
   runTestVM(vm, &configuration, "import \"foo|bar\"");
 }
 
-static void shared(WrenVM* vm)
+static void shared(WrenVM* vm, void *userData)
 {
   WrenConfiguration configuration;
   wrenInitConfiguration(&configuration);
@@ -132,7 +132,7 @@ static void shared(WrenVM* vm)
   runTestVM(vm, &configuration, "import \"foo|bar\"\nimport \"foo/bar\"");
 }
 
-static void importer(WrenVM* vm)
+static void importer(WrenVM* vm, void *userData)
 {
   WrenConfiguration configuration;
   wrenInitConfiguration(&configuration);

--- a/test/api/slots.c
+++ b/test/api/slots.c
@@ -3,12 +3,12 @@
 
 #include "slots.h"
 
-static void noSet(WrenVM* vm)
+static void noSet(WrenVM* vm, void *userData)
 {
   // Do nothing.
 }
 
-static void getSlots(WrenVM* vm)
+static void getSlots(WrenVM* vm, void *userData)
 {
   bool result = true;
   if (wrenGetSlotBool(vm, 1) != true) result = false;
@@ -37,7 +37,7 @@ static void getSlots(WrenVM* vm)
   wrenReleaseHandle(vm, handle);
 }
 
-static void setSlots(WrenVM* vm)
+static void setSlots(WrenVM* vm, void *userData)
 {
   WrenHandle* handle = wrenGetSlotHandle(vm, 1);
 
@@ -76,7 +76,7 @@ static void setSlots(WrenVM* vm)
   wrenReleaseHandle(vm, handle);
 }
 
-static void slotTypes(WrenVM* vm)
+static void slotTypes(WrenVM* vm, void *userData)
 {
   bool result =
       wrenGetSlotType(vm, 1) == WREN_TYPE_BOOL &&
@@ -91,7 +91,7 @@ static void slotTypes(WrenVM* vm)
   wrenSetSlotBool(vm, 0, result);
 }
 
-static void ensure(WrenVM* vm)
+static void ensure(WrenVM* vm, void *userData)
 {
   int before = wrenGetSlotCount(vm);
 
@@ -117,7 +117,7 @@ static void ensure(WrenVM* vm)
   wrenSetSlotString(vm, 0, result);
 }
 
-static void ensureOutsideForeign(WrenVM* vm)
+static void ensureOutsideForeign(WrenVM* vm, void *userData)
 {
   // To test the behavior outside of a foreign method (which we're currently
   // in), create a new separate VM.
@@ -151,23 +151,23 @@ static void ensureOutsideForeign(WrenVM* vm)
   wrenSetSlotString(vm, 0, result);
 }
 
-static void foreignClassAllocate(WrenVM* vm)
+static void foreignClassAllocate(WrenVM* vm, void *userData)
 {
   wrenSetSlotNewForeign(vm, 0, 0, 4);
 }
 
-static void getListCount(WrenVM* vm)
+static void getListCount(WrenVM* vm, void *userData)
 {
   wrenSetSlotDouble(vm, 0, wrenGetListCount(vm, 1));
 }
 
-static void getListElement(WrenVM* vm)
+static void getListElement(WrenVM* vm, void *userData)
 {
   int index = (int)wrenGetSlotDouble(vm, 2);
   wrenGetListElement(vm, 1, index, 0);
 }
 
-static void getMapValue(WrenVM* vm)
+static void getMapValue(WrenVM* vm, void *userData)
 {
   wrenGetMapValue(vm, 1, 2, 0);
 }

--- a/test/api/user_data.c
+++ b/test/api/user_data.c
@@ -17,7 +17,7 @@ void* testReallocateFn(void* ptr, size_t newSize, void* userData) {
   return realloc(ptr, newSize);
 }
 
-static void test(WrenVM* vm)
+static void test(WrenVM* vm, void *userData)
 {
   WrenConfiguration configuration;
   wrenInitConfiguration(&configuration);


### PR DESCRIPTION
This lets a single WrenForeignMethodFn implement multiple foreign methods or otherwise change its behaviour based on a `void *userData`.  My use case is the [Vala bindings](https://github.com/cxw42/wren-vala/tree/marshal), in which I dispatch from a single WrenForeignMethodFn to any number of implementations based on `userData`.  However, I believe others will find many uses for this!

Thank you for considering this PR!

High-level changes:
- Make `WrenForeignMethodFn` take `(WrenVM* vm, void *userData)` instead of just `vm`
- Make `WrenBindForeignMethodFn` return both a `WrenForeignMethodFn` and a `userData` value
- Corresponding changes throughout

Notes:

- All tests pass
- Fixes #942.  Makes it much easier to implement #959 (only about 10 more lines of code! --- [example](https://github.com/cxw42/wren/commit/d535f1629be231846186d0e4363109f4a00d5000))
- I am happy to make this a compile-time option if you would like.
- I can also split up the changes into commit(s) differently.

### Timing analysis

This plot shows the results from the baseline txt file.  (I think this is score, so higher numbers are better, but I'm not sure.)  I ran `benchmark.py --generate-baseline` 10 times for each commit, and saved the baseline.txt files.

![summary-comparison](https://user-images.githubusercontent.com/10515894/114644683-ffcb9100-9ca5-11eb-8e82-51697961f3a0.png)

The tests are, in order left to right:

1. api_call
2. api_foreign_method
3. binary_trees
4. binary_trees_gc
5. delta_blue
6. fib
7. fibers
8. for
9. map_numeric
10. map_string
11. method_call
12. string_equals

I do not know why the change in `api_call` --- I looked at the code, and it is barely making any foreign method calls that I can tell.  Any ideas?
