### PR TITLE
benchmark.py: clarify variable names [refactor]

### DIFF
--- a/util/benchmark.py
+++ b/util/benchmark.py
@@ -47,6 +47,8 @@ BENCHMARK_DIR = relpath(BENCHMARK_DIR).replace("\\", "/")
 # How many times to run a given benchmark.
 NUM_TRIALS = 10
 
+# Results.  Columns are [0]=name, [1]=regex to match against stdout to check
+# if the benchmark succeeded, [2]=best score (from get_score())
 BENCHMARKS = []
 
 def BENCHMARK(name, pattern):
@@ -196,8 +198,8 @@ def run_benchmark_language(benchmark, language, benchmark_result):
     times.append(time)
     sys.stdout.write(".")
 
-  best = min(times)
-  score = get_score(best)
+  best_time = min(times)
+  score = get_score(best_time)
 
   comparison = ""
   if language[0] == "wren":
@@ -221,7 +223,7 @@ def run_benchmark_language(benchmark, language, benchmark_result):
       comparison = red(comparison)
 
   print(" {:4.2f}s {:4.4f} {:s}".format(
-      best,
+      best_time,
       standard_deviation(times),
       comparison))
 
@@ -281,11 +283,11 @@ def read_baseline():
   if os.path.exists(baseline_file):
     with open(baseline_file) as f:
       for line in f.readlines():
-        name, best = line.split(",")
+        name, score = line.split(",")
         for benchmark in BENCHMARKS:
           if benchmark[0] == name:
-            if not best.startswith("None"):
-              benchmark[2] = float(best)
+            if not score.startswith("None"):
+              benchmark[2] = float(score)
             else:
               benchmark[2] = 0.0
 
@@ -294,8 +296,8 @@ def generate_baseline():
   print("generating baseline")
   baseline_text = ""
   for benchmark in BENCHMARKS:
-    best = run_benchmark_language(benchmark, LANGUAGES[0], {})
-    baseline_text += ("{},{}\n".format(benchmark[0], best))
+    score = run_benchmark_language(benchmark, LANGUAGES[0], {})
+    baseline_text += ("{},{}\n".format(benchmark[0], score))
 
   # Write them to a file.
   baseline_file = os.path.join(BENCHMARK_DIR, "baseline.txt")


### PR DESCRIPTION
When you run benchmark.py, the baseline.txt file saves the score (1000/best_time) ([ref](https://github.com/wren-lang/wren/blob/22ff3b5549fb29cc36d4d03ed35120348483af29/util/benchmark.py#L234); analysis below).  However, [elsewhere in benchmark.py](https://github.com/wren-lang/wren/blob/22ff3b5549fb29cc36d4d03ed35120348483af29/util/benchmark.py#L297), the code says `best = run_benchmark_language(...)`.  The use of `best` suggests that time is stored in the baseline file.  I found this confusing when I was running my first timing analysis.

In hopes of helping future newcomers to benchmark.py, this PR:

- Changes variable names to clarify that the value in the baseline.txt file is a score, not a time.
- Updates `best` to `best_time` where it's a time and not a score, to reduce the chance of confusion.
- Adds a comment explaining the indices in `benchmark`.

No functional changes.  Thanks for considering this PR!

### Supporting data

I did a benchmark run and got:

```
$ ./util/benchmark.py --generate-baseline -l wren
generating baseline
api_call - wren                .......... 0.08s 0.0032 no baseline
api_foreign_method - wren      .......... 0.55s 0.0061 no baseline
binary_trees - wren            .......... 0.34s 0.0045 no baseline
binary_trees_gc - wren         .......... 1.56s 0.0170 no baseline
delta_blue - wren              .......... 0.27s 0.0071 no baseline
fib - wren                     .......... 0.31s 0.0053 no baseline
fibers - wren                  .......... 0.08s 0.0012 no baseline
for - wren                     .......... 0.14s 0.0088 no baseline
method_call - wren             .......... 0.17s 0.0031 no baseline
map_numeric - wren             .......... 1.59s 0.0155 no baseline
map_string - wren              .......... 0.16s 0.0020 no baseline
string_equals - wren           .......... 0.34s 0.0089 no baseline

$ cat test/benchmark/baseline.txt 
api_call,11890.1822765
api_foreign_method,1814.79310451
binary_trees,2947.5570647
binary_trees_gc,641.007561325
delta_blue,3722.6062711
fib,3175.61130518
fibers,12971.6828164
for,7057.36224029
method_call,5840.13222059
map_numeric,627.938359059
map_string,6210.29293952
string_equals,2962.00634462
```

To take one example, `binary_trees_gc` has a time of `1.56s` and a `baseline.txt` value of ~641.  1000/1.56 ~= 641, confirming that the baseline.txt is storing scores, not times.