### PR TITLE
doc: fix links from Object documentation to Values documentation

### DIFF
--- a/doc/site/modules/core/object.markdown
+++ b/doc/site/modules/core/object.markdown
@@ -5,7 +5,7 @@
 ### **same**(obj1, obj2)
 
 Returns `true` if *obj1* and *obj2* are the same. For [value
-types](../values.html), this returns `true` if the objects have equivalent
+types](../../values.html), this returns `true` if the objects have equivalent
 state. In other words, numbers, strings, booleans, and ranges compare by value.
 
 For all other objects, this returns `true` only if *obj1* and *obj2* refer to
@@ -26,7 +26,7 @@ Returns `false`, since most objects are considered [true][].
 ### **==**(other) and **!=**(other) operators
 
 Compares two objects using built-in equality. This compares [value
-types](../values.html) by value, and all other objects are compared by
+types](../../values.html) by value, and all other objects are compared by
 identity&mdash;two objects are equal only if they are the exact same object.
 
 ### **is**(class) operator


### PR DESCRIPTION
Currently, on <https://wren.io/modules/core/object.html>, I see:

![image](https://user-images.githubusercontent.com/10515894/114957840-d2125380-9e2f-11eb-883f-453f4c8f9fb6.png)

(`modules/values.html` instead of `values.html`).  This PR fixes that!