### PR TITLE
Minor docs fixes.

### DIFF
--- a/doc/site/modularity.markdown
+++ b/doc/site/modularity.markdown
@@ -318,7 +318,7 @@ for (i in 1..2) {
 System.print(3)    //>  not reached
 </pre>
 
-Although it is not invalid to return a value, there is no way to access that value and it is therefore simply discarded.
+Although it is not invalid to return a value, it can only be accessed using meta-programming - reading the file contents and compiling them with the Meta.compile method. Otherwise it would simply be discarded.
 
 <br><hr>
 <a href="error-handling.html">&larr; Error Handling</a>


### PR DESCRIPTION
Commits to fix a couple of problems:

1. The `Exiting a module early` section in the light of https://github.com/wren-lang/wren/issues/974#issuecomment-821582815 by @clsource. Not sure we need to go into too much detail here so I've just hinted at how it could be done.

2. The `Meta` class docs where in my previous PR I should have prefixed the static methods with the class name to be consistent with how this is done in the rest of the docs.