### PR TITLE
Add note about closures capturing their surrounding scope by reference

### DIFF
--- a/doc/site/functions.markdown
+++ b/doc/site/functions.markdown
@@ -97,6 +97,11 @@ System.print(counter.call()) //> 2
 System.print(counter.call()) //> 3
 </pre>
 
+Variables outside the scope of the closure are captured by reference and not by
+copy, so writing to a captured variable will mutate it in the outer scope as 
+well. If you're familiar with C++, you can think of it like using [&] when 
+creating a lambda.
+
 ## Callable classes
 
 Because `Fn` is a class, and responds to `call()`, any class can respond to 


### PR DESCRIPTION
We had a discussion on Discord related to this commit that was sparked by clsource. He provided the following code:
```lua
var printNumbers = Fn.new {
    var numbersToPrint = []
    var i = 0
    while (i < 10) {
        numbersToPrint.add(Fn.new {
            System.print(i)
        })
        i = i + 1
    }

    return numbersToPrint
}

var numbers = printNumbers.call()

// Prints only 10
numbers.each {|fn| fn.call()}
```

Which (rather surprisingly) only prints 10. To get the expected behavior, you need to copy the variable i in each iteration and use the copied variable in the closure. This patch adds a note in the documentation so that new users aren't surprised by this.