### PR TITLE
wren/language: Add unary `+` operator.

### DIFF
--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -205,6 +205,18 @@ System.print(1.5.truncate)    //> 1
 System.print((-3.2).truncate) //> -3
 </pre>
 
+### **+** operator
+
+Returns the identity of the number.
+
+<pre class="snippet">
+var a = +123
+System.print(a) //> 123
+
+var b = -123
+System.print(+b) //> -123
+</pre>
+
 ### **-** operator
 
 Negates the number.

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1722,7 +1722,7 @@ typedef enum
   PREC_RANGE,         // .. ...
   PREC_TERM,          // + -
   PREC_FACTOR,        // * / %
-  PREC_UNARY,         // unary - ! ~
+  PREC_UNARY,         // unary + - ! ~
   PREC_CALL,          // . () []
   PREC_PRIMARY
 } Precedence;
@@ -2759,7 +2759,7 @@ GrammarRule rules[] =
   /* TOKEN_SLASH         */ INFIX_OPERATOR(PREC_FACTOR, "/"),
   /* TOKEN_PERCENT       */ INFIX_OPERATOR(PREC_FACTOR, "%"),
   /* TOKEN_HASH          */ UNUSED,
-  /* TOKEN_PLUS          */ INFIX_OPERATOR(PREC_TERM, "+"),
+  /* TOKEN_PLUS          */ OPERATOR("+"),
   /* TOKEN_MINUS         */ OPERATOR("-"),
   /* TOKEN_LTLT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, "<<"),
   /* TOKEN_GTGT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, ">>"),

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -696,7 +696,8 @@ DEF_NUM_FN(cbrt,    cbrt)
 DEF_NUM_FN(ceil,    ceil)
 DEF_NUM_FN(cos,     cos)
 DEF_NUM_FN(floor,   floor)
-DEF_NUM_FN(negate,  -)
+DEF_NUM_FN(unary_plus,  +)
+DEF_NUM_FN(unary_minus, -)
 DEF_NUM_FN(round,   round)
 DEF_NUM_FN(sin,     sin)
 DEF_NUM_FN(sqrt,    sqrt)
@@ -1379,7 +1380,8 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->numClass, "ceil", num_ceil);
   PRIMITIVE(vm->numClass, "cos", num_cos);
   PRIMITIVE(vm->numClass, "floor", num_floor);
-  PRIMITIVE(vm->numClass, "-", num_negate);
+  PRIMITIVE(vm->numClass, "+", num_unary_plus);
+  PRIMITIVE(vm->numClass, "-", num_unary_minus);
   PRIMITIVE(vm->numClass, "round", num_round);
   PRIMITIVE(vm->numClass, "min(_)", num_min);
   PRIMITIVE(vm->numClass, "max(_)", num_max);

--- a/test/core/number/minus.wren
+++ b/test/core/number/minus.wren
@@ -3,6 +3,9 @@ System.print(5 - 3)      // expect: 2
 System.print(3.1 - 0.24) // expect: 2.86
 System.print(3 - 2 - 1)  // expect: 0
 
-// Unary negation.
-var a = 3
-System.print(-a) // expect: -3
+// Unary minus.
+var a = -3
+System.print(a) // expect: -3
+
+var b = 3
+System.print(-b) // expect: -3

--- a/test/core/number/plus.wren
+++ b/test/core/number/plus.wren
@@ -1,3 +1,10 @@
 System.print(1 + 2) // expect: 3
 System.print(12.34 + 0.13) // expect: 12.47
 System.print(3 + 5 + 2) // expect: 10
+
+// Unary plus.
+var a = +3
+System.print(a) // expect: 3
+
+var b = -3
+System.print(+b) // expect: -3


### PR DESCRIPTION
For the sake of completeness and to ease pretty formatting, allow numbers to be be prefixed with `+`.