### PR TITLE
Simplify starting bool arithmetic

### DIFF
--- a/doc/site/modules/core/bool.markdown
+++ b/doc/site/modules/core/bool.markdown
@@ -18,3 +18,7 @@ System.print(!false) //> true
 ### toString
 
 The string representation of the value, either `"true"` or `"false"`.
+
+### toNum
+
+The number representation of the value, either `1` or `0`.

--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -194,6 +194,17 @@ The tangent of the number.
 
 The string representation of the number.
 
+### **toBool**
+
+The bool representation of the number. Equal to `>= 1`
+
+<pre class="snippet">
+System.print((-1).toBool)  //> false
+System.print((0.8).toBool) //> false
+System.print(1.toBool)     //> true
+System.print(2.toBool)     //> true
+</pre>
+
 ### **truncate**
 
 Rounds the number to the nearest integer towards zero.

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -30,6 +30,18 @@ DEF_PRIMITIVE(bool_toString)
   }
 }
 
+DEF_PRIMITIVE(bool_toNum)
+{
+    if (AS_BOOL(args[0]))
+    {
+        RETURN_NUM(1);
+    }
+    else
+    {
+        RETURN_NUM(0);
+    }
+}
+
 DEF_PRIMITIVE(class_name)
 {
   RETURN_OBJ(AS_CLASS(args[0])->name);
@@ -836,6 +848,18 @@ DEF_PRIMITIVE(num_toString)
   RETURN_VAL(wrenNumToString(vm, AS_NUM(args[0])));
 }
 
+DEF_PRIMITIVE(num_toBool)
+{
+  if (AS_NUM(args[0]) >= 1)
+  {
+    RETURN_TRUE;
+  }
+  else
+  {
+    RETURN_FALSE;
+  }
+}
+
 DEF_PRIMITIVE(num_truncate)
 {
   double integer;
@@ -1300,6 +1324,7 @@ void wrenInitializeCore(WrenVM* vm)
 
   vm->boolClass = AS_CLASS(wrenFindVariable(vm, coreModule, "Bool"));
   PRIMITIVE(vm->boolClass, "toString", bool_toString);
+  PRIMITIVE(vm->boolClass, "toNum", bool_toNum);
   PRIMITIVE(vm->boolClass, "!", bool_not);
 
   vm->fiberClass = AS_CLASS(wrenFindVariable(vm, coreModule, "Fiber"));
@@ -1402,6 +1427,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->numClass, "isNan", num_isNan);
   PRIMITIVE(vm->numClass, "sign", num_sign);
   PRIMITIVE(vm->numClass, "toString", num_toString);
+  PRIMITIVE(vm->numClass, "toBool", num_toBool);
   PRIMITIVE(vm->numClass, "truncate", num_truncate);
 
   // These are defined just so that 0 and -0 are equal, which is specified by

--- a/test/core/bool/to_num.wren
+++ b/test/core/bool/to_num.wren
@@ -1,0 +1,2 @@
+System.print(true.toNum)  // expect: 1
+System.print(false.toNum) // expect: 0

--- a/test/core/number/to_bool.wren
+++ b/test/core/number/to_bool.wren
@@ -1,0 +1,4 @@
+System.print(0.toBool) // expect: false
+System.print(1.toBool) // expect: true
+System.print((123.45).toBool) // expect: true
+System.print((-123.45).toBool) // expect: false


### PR DESCRIPTION
Adds Num.toBool and Bool.toNum to 

Based on discord discussion https://discord.com/channels/484796661751873554/484796759437213716/834912554450157598 and github discussion https://github.com/wren-lang/wren/pull/985#issuecomment-825587935

This would allow for instance (code sample based on the discord discussion)
```js
var direction = Keyboard["right"].justPressed.toNum - Keyboard["left"].justPressed.toNum

position.x = position.x + (direction * velocity)

if (direction.toBool) {
  // is moving
}
```
