### PR TITLE
Add System.version

### DIFF
--- a/doc/site/modules/core/system.markdown
+++ b/doc/site/modules/core/system.markdown
@@ -5,6 +5,10 @@ use during development or debugging.
 
 ## Static Methods
 
+### System.**version**
+
+Returns a monotonical numeric value representing the Wren version. Use this if you want to do range checks over versions.
+
 ### System.**clock**
 
 Returns the number of seconds (including fractional seconds) since the program

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -1197,6 +1197,11 @@ DEF_PRIMITIVE(string_toString)
   RETURN_VAL(args[0]);
 }
 
+DEF_PRIMITIVE(system_version)
+{
+  RETURN_NUM(WREN_VERSION_NUMBER);
+}
+
 DEF_PRIMITIVE(system_clock)
 {
   RETURN_NUM((double)clock() / CLOCKS_PER_SEC);
@@ -1468,6 +1473,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->rangeClass, "toString", range_toString);
 
   ObjClass* systemClass = AS_CLASS(wrenFindVariable(vm, coreModule, "System"));
+  PRIMITIVE(systemClass->obj.classObj, "version", system_version);
   PRIMITIVE(systemClass->obj.classObj, "clock", system_clock);
   PRIMITIVE(systemClass->obj.classObj, "gc()", system_gc);
   PRIMITIVE(systemClass->obj.classObj, "writeString_(_)", system_writeString);

--- a/test/core/system/print.wren
+++ b/test/core/system/print.wren
@@ -10,3 +10,6 @@ System.print(Foo.new()) // expect: Foo.toString
 // Returns the argument.
 System.print(System.print(1) == 1) // expect: 1
                                    // expect: true
+
+// System.version
+System.print(System.version)


### PR DESCRIPTION
References https://github.com/wren-lang/wren-cli/issues/95

``` js
System.version
```

It returns `WREN_VERSION_NUMBER`. Was thinking of retrieving the string, or having version.major, version.minor, but I think keeping it dead simple like this is best.