### PR TITLE
Add octal escape sequences

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -874,6 +874,28 @@ static int readHexEscape(Parser* parser, int digits, const char* description)
   return value;
 }
 
+static uint8_t readOctalEscape(Parser *parser, char c) {
+  int value = c - '0';
+  // Octal escapes can be at most 3 digits.
+  for (int i = 0; i < 2; i++)
+  {
+    c = peekChar(parser);
+    if (c >= '0' && c < '8')
+    {
+      value = value * 8 + nextChar(parser) - '0';
+    }
+    else break;
+  }
+
+  // Octal escapes must fit in a byte.
+  if (value > 255)
+  {
+    lexError(parser, "Invalid octal escape sequence.");
+    return 0;
+  }
+  return (uint8_t)value;
+}
+
 // Reads a hex digit Unicode escape sequence in a string literal.
 static void readUnicodeEscape(Parser* parser, ByteBuffer* string, int length)
 {
@@ -1008,7 +1030,6 @@ static void readString(Parser* parser)
         case '"':  wrenByteBufferWrite(parser->vm, &string, '"'); break;
         case '\\': wrenByteBufferWrite(parser->vm, &string, '\\'); break;
         case '%':  wrenByteBufferWrite(parser->vm, &string, '%'); break;
-        case '0':  wrenByteBufferWrite(parser->vm, &string, '\0'); break;
         case 'a':  wrenByteBufferWrite(parser->vm, &string, '\a'); break;
         case 'b':  wrenByteBufferWrite(parser->vm, &string, '\b'); break;
         case 'e':  wrenByteBufferWrite(parser->vm, &string, '\33'); break;
@@ -1025,8 +1046,13 @@ static void readString(Parser* parser)
           break;
 
         default:
-          lexError(parser, "Invalid escape character '%c'.",
-                   *(parser->currentChar - 1));
+          c = *(parser->currentChar - 1);
+          if (c >= '0' && c < '8') {
+            wrenByteBufferWrite(parser->vm, &string,
+                                readOctalEscape(parser, c));
+            break;
+          }
+          lexError(parser, "Invalid escape character '%c'.", c);
           break;
       }
     }

--- a/test/language/string/invalid_escape_with_digits.wren
+++ b/test/language/string/invalid_escape_with_digits.wren
@@ -1,0 +1,2 @@
+// expect error line 2
+"\8"

--- a/test/language/string/invalid_octal_escape.wren
+++ b/test/language/string/invalid_octal_escape.wren
@@ -1,0 +1,2 @@
+// expect error line 2
+"\777"

--- a/test/language/string/octal_escapes.wren
+++ b/test/language/string/octal_escapes.wren
@@ -1,0 +1,15 @@
+var bytes = "\0\00\000\0000\033\377\089".bytes
+
+System.print(bytes[0]) // expect: 0
+System.print(bytes[1]) // expect: 0
+System.print(bytes[2]) // expect: 0
+System.print(bytes[3]) // expect: 0
+// "0".
+System.print(bytes[4]) // expect: 48
+System.print(bytes[5]) // expect: 27
+System.print(bytes[6]) // expect: 255
+System.print(bytes[7]) // expect: 0
+// "8".
+System.print(bytes[8]) // expect: 56
+// "9".
+System.print(bytes[9]) // expect: 57


### PR DESCRIPTION
This allows the use of octal escape sequences in string literals. Octal escapes are represented with a back slash followed by at least 1 and at most 3 octal digits. Octal escape sequences also cannot exceed 255 (the max value for an unsigned byte).

The two most common use cases for octal escapes are null bytes represented as`\0`, and ANSI escape sequences represented as `\033` or `\33` which is functionally similar to `\e`.
