### PR TITLE
Prevents the compiler from printing unprintable chars for escape sequences

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1025,8 +1025,19 @@ static void readString(Parser* parser)
           break;
 
         default:
-          lexError(parser, "Invalid escape character '%c'.",
-                   *(parser->currentChar - 1));
+          c = *(parser->currentChar - 1);
+          if (c >= 32 && c <= 126)
+          {
+            lexError(parser, "Invalid escape character '%c'.", c);
+          }
+          else
+          {
+            // Don't show non-ASCII values since we didn't UTF-8 decode the
+            // bytes. Since there are no non-ASCII byte values that are
+            // meaningful escape sequences in Wren, the lexer works on raw 
+            // bytes, even though the source code and console output are UTF-8.
+            lexError(parser, "Invalid byte 0x%x in escape sequence.", (uint8_t)c);
+          }
           break;
       }
     }


### PR DESCRIPTION
Fixed an issue where invalid escape sequences can print bytes that were not meant to be printed, thus sometimes corrupting error messages.
![image](https://user-images.githubusercontent.com/14926524/116801454-05efa900-aabf-11eb-85a1-a9c1334bdfcb.png)
After fix...
![image](https://user-images.githubusercontent.com/14926524/116801486-50712580-aabf-11eb-8298-28ec0ef1fddb.png)
