### PR TITLE
Adding fields support to foreign class #994 by adding ObjMemorySegment

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -2247,10 +2247,6 @@ static void field(Compiler* compiler, bool canAssign)
   {
     error(compiler, "Cannot reference a field outside of a class definition.");
   }
-  else if (enclosingClass->isForeign)
-  {
-    error(compiler, "Cannot define fields in a foreign class.");
-  }
   else if (enclosingClass->inStatic)
   {
     error(compiler, "Cannot use an instance field in a static method.");

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -1224,7 +1224,7 @@ static ObjClass* defineClass(WrenVM* vm, ObjModule* module, const char* name)
   ObjString* nameString = AS_STRING(wrenNewString(vm, name));
   wrenPushRoot(vm, (Obj*)nameString);
 
-  ObjClass* classObj = wrenNewSingleClass(vm, 0, nameString);
+  ObjClass* classObj = wrenNewSingleClass(vm, false, 0, nameString);
 
   wrenDefineVariable(vm, module, name, nameString->length, OBJ_VAL(classObj), NULL);
 

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -295,7 +295,13 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       break;
     }
 
-    case CODE_FOREIGN_CLASS: printf("FOREIGN_CLASS\n"); break;
+    case CODE_FOREIGN_CLASS:
+    {
+      int numFields = READ_BYTE();
+      printf("%-16s %5d fields\n", "FOREIGN_CLASS", numFields);
+      break;
+    }
+
     case CODE_END_CLASS: printf("END_CLASS\n"); break;
 
     case CODE_METHOD_INSTANCE:

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -260,7 +260,7 @@ void wrenEnsureStack(WrenVM* vm, ObjFiber* fiber, int needed)
 
 ObjMemorySegment* wrenNewForeign(WrenVM* vm, ObjClass* classObj, size_t size)
 {
-  Value value = wrenNewMemorySegment(vm, OBJ_FOREIGN, classObj, 0, size);
+  Value value = wrenNewMemorySegment(vm, OBJ_FOREIGN, classObj, classObj->numFields, size);
   return AS_MEMORYSEGMENT(value);
 }
 

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -92,15 +92,7 @@ void wrenBindSuperclass(WrenVM* vm, ObjClass* subclass, ObjClass* superclass)
   subclass->superclass = superclass;
 
   // Include the superclass in the total number of fields.
-  if (!subclass->isForeign)
-  {
-    subclass->numFields += superclass->numFields;
-  }
-  else
-  {
-    ASSERT(superclass->numFields == 0,
-           "A foreign class cannot inherit from a class with fields.");
-  }
+  subclass->numFields += superclass->numFields;
 
   // Inherit methods from its superclass.
   for (int i = 0; i < superclass->methods.count; i++)

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -290,17 +290,8 @@ void wrenFunctionBindName(WrenVM* vm, ObjFn* fn, const char* name, int length)
 
 Value wrenNewInstance(WrenVM* vm, ObjClass* classObj)
 {
-  ObjInstance* instance = ALLOCATE_FLEX(vm, ObjInstance,
-                                        Value, classObj->numFields);
-  initObj(vm, &instance->obj, OBJ_INSTANCE, classObj);
-
-  // Initialize fields to null.
-  for (int i = 0; i < classObj->numFields; i++)
-  {
-    instance->fields[i] = NULL_VAL;
-  }
-
-  return OBJ_VAL(instance);
+  return wrenNewMemorySegment(vm, OBJ_INSTANCE,
+                              classObj, classObj->numFields, 0);
 }
 
 ObjList* wrenNewList(WrenVM* vm, uint32_t numElements)
@@ -1136,18 +1127,6 @@ static void blackenFn(WrenVM* vm, ObjFn* fn)
   // TODO: What about the function name?
 }
 
-static void blackenInstance(WrenVM* vm, ObjInstance* instance)
-{
-  wrenGrayObj(vm, (Obj*)instance->obj.classObj);
-
-  // Mark the fields.
-  wrenGrayValues(vm, instance->fields, instance->obj.classObj->numFields);
-
-  // Keep track of how much memory is still in use.
-  vm->bytesAllocated += sizeof(ObjInstance);
-  vm->bytesAllocated += sizeof(Value) * instance->obj.classObj->numFields;
-}
-
 static void blackenList(WrenVM* vm, ObjList* list)
 {
   // Mark the elements.
@@ -1224,8 +1203,8 @@ static void blackenObject(WrenVM* vm, Obj* obj)
     case OBJ_CLOSURE:  blackenClosure( vm, (ObjClosure*) obj); break;
     case OBJ_FIBER:    blackenFiber(   vm, (ObjFiber*)   obj); break;
     case OBJ_FN:       blackenFn(      vm, (ObjFn*)      obj); break;
-    case OBJ_FOREIGN:  blackenMemorySegment(vm, (ObjMemorySegment*)obj); break;
-    case OBJ_INSTANCE: blackenInstance(vm, (ObjInstance*)obj); break;
+    case OBJ_FOREIGN:
+    case OBJ_INSTANCE: blackenMemorySegment(vm, (ObjMemorySegment*)obj); break;
     case OBJ_LIST:     blackenList(    vm, (ObjList*)    obj); break;
     case OBJ_MAP:      blackenMap(     vm, (ObjMap*)     obj); break;
     case OBJ_MODULE:   blackenModule(  vm, (ObjModule*)  obj); break;

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -405,6 +405,8 @@ struct sObjClass
   Obj obj;
   ObjClass* superclass;
 
+  bool isForeign;
+
   // The number of fields needed for an instance of this class, including all
   // of its superclass fields.
   int numFields;
@@ -645,7 +647,8 @@ static inline void *wrenMemorySegmentData(ObjMemorySegment *ms)
 // Creates a new "raw" class. It has no metaclass or superclass whatsoever.
 // This is only used for bootstrapping the initial Object and Class classes,
 // which are a little special.
-ObjClass* wrenNewSingleClass(WrenVM* vm, int numFields, ObjString* name);
+ObjClass* wrenNewSingleClass(WrenVM* vm, bool isForeign, int numFields,
+                             ObjString* name);
 
 // Makes [superclass] the superclass of [subclass], and causes subclass to
 // inherit its methods. This should be called before any methods are defined
@@ -653,8 +656,8 @@ ObjClass* wrenNewSingleClass(WrenVM* vm, int numFields, ObjString* name);
 void wrenBindSuperclass(WrenVM* vm, ObjClass* subclass, ObjClass* superclass);
 
 // Creates a new class object as well as its associated metaclass.
-ObjClass* wrenNewClass(WrenVM* vm, ObjClass* superclass, int numFields,
-                       ObjString* name);
+ObjClass* wrenNewClass(WrenVM* vm, ObjClass* superclass, bool isForeign,
+                       int numFields, ObjString* name);
 
 void wrenBindMethod(WrenVM* vm, ObjClass* classObj, int symbol, Method method);
 

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -50,7 +50,6 @@
 #define AS_CLOSURE(value)   ((ObjClosure*)AS_OBJ(value))        // ObjClosure*
 #define AS_FIBER(v)         ((ObjFiber*)AS_OBJ(v))              // ObjFiber*
 #define AS_FN(value)        ((ObjFn*)AS_OBJ(value))             // ObjFn*
-#define AS_INSTANCE(value)  ((ObjInstance*)AS_OBJ(value))       // ObjInstance*
 #define AS_LIST(value)      ((ObjList*)AS_OBJ(value))           // ObjList*
 #define AS_MAP(value)       ((ObjMap*)AS_OBJ(value))            // ObjMap*
 #define AS_MEMORYSEGMENT(value)        /* ObjMemorySegment* */                \
@@ -80,7 +79,7 @@
 #define IS_LIST(value) (wrenIsObjType(value, OBJ_LIST))         // ObjList
 #define IS_MAP(value) (wrenIsObjType(value, OBJ_MAP))           // ObjMap
 #define IS_MEMORYSEGMENT(value)        /* ObjMemorySegment */                 \
-    (IS_FOREIGN(value))
+    (IS_FOREIGN(value) || IS_INSTANCE(value))
 #define IS_RANGE(value) (wrenIsObjType(value, OBJ_RANGE))       // ObjRange
 #define IS_STRING(value) (wrenIsObjType(value, OBJ_STRING))     // ObjString
 
@@ -426,12 +425,6 @@ struct sObjClass
   // The ClassAttribute for the class, if any
   Value attributes;
 };
-
-typedef struct
-{
-  Obj obj;
-  Value fields[FLEXIBLE_ARRAY];
-} ObjInstance;
 
 typedef struct
 {

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -50,7 +50,6 @@
 #define AS_CLOSURE(value)   ((ObjClosure*)AS_OBJ(value))        // ObjClosure*
 #define AS_FIBER(v)         ((ObjFiber*)AS_OBJ(v))              // ObjFiber*
 #define AS_FN(value)        ((ObjFn*)AS_OBJ(value))             // ObjFn*
-#define AS_FOREIGN(v)       ((ObjForeign*)AS_OBJ(v))            // ObjForeign*
 #define AS_INSTANCE(value)  ((ObjInstance*)AS_OBJ(value))       // ObjInstance*
 #define AS_LIST(value)      ((ObjList*)AS_OBJ(value))           // ObjList*
 #define AS_MAP(value)       ((ObjMap*)AS_OBJ(value))            // ObjMap*
@@ -80,6 +79,8 @@
 #define IS_INSTANCE(value) (wrenIsObjType(value, OBJ_INSTANCE)) // ObjInstance
 #define IS_LIST(value) (wrenIsObjType(value, OBJ_LIST))         // ObjList
 #define IS_MAP(value) (wrenIsObjType(value, OBJ_MAP))           // ObjMap
+#define IS_MEMORYSEGMENT(value)        /* ObjMemorySegment */                 \
+    (IS_FOREIGN(value))
 #define IS_RANGE(value) (wrenIsObjType(value, OBJ_RANGE))       // ObjRange
 #define IS_STRING(value) (wrenIsObjType(value, OBJ_STRING))     // ObjString
 
@@ -429,12 +430,6 @@ struct sObjClass
 typedef struct
 {
   Obj obj;
-  uint8_t data[FLEXIBLE_ARRAY];
-} ObjForeign;
-
-typedef struct
-{
-  Obj obj;
   Value fields[FLEXIBLE_ARRAY];
 } ObjInstance;
 
@@ -699,7 +694,7 @@ static inline bool wrenHasError(const ObjFiber* fiber)
   return !IS_NULL(fiber->error);
 }
 
-ObjForeign* wrenNewForeign(WrenVM* vm, ObjClass* classObj, size_t size);
+ObjMemorySegment* wrenNewForeign(WrenVM* vm, ObjClass* classObj, size_t size);
 
 // Creates a new empty function. Before being used, it must have code,
 // constants, etc. added to it.

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -535,14 +535,14 @@ static Value validateSuperclass(WrenVM* vm, Value name, Value superclassValue,
         name, OBJ_VAL(superclass->name));
   }
 
-  if (superclass->isForeign)
+  if (!isForeign && superclass->isForeign)
   {
     return wrenStringFormat(vm,
         "Class '@' cannot inherit from foreign class '@'.",
         name, OBJ_VAL(superclass->name));
   }
 
-  if (isForeign && superclass->numFields > 0)
+  if (isForeign && !superclass->isForeign && superclass->numFields > 0)
   {
     return wrenStringFormat(vm,
         "Foreign class '@' may not inherit from a class with fields.",

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -677,7 +677,7 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
   vm->apiStack = NULL;
 }
 
-void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign)
+void wrenFinalizeForeign(WrenVM* vm, ObjMemorySegment* foreign)
 {
   // TODO: Don't look up every time.
   int symbol = wrenSymbolTableFind(&vm->methodNames, "<finalize>", 10);
@@ -696,7 +696,7 @@ void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign)
   ASSERT(method->type == METHOD_FOREIGN, "Finalizer should be foreign.");
 
   WrenFinalizerFn finalizer = (WrenFinalizerFn)method->as.foreign;
-  finalizer(foreign->data);
+  finalizer(wrenMemorySegmentData(foreign));
 }
 
 // Let the host resolve an imported module name if it wants to.
@@ -1705,7 +1705,7 @@ void* wrenGetSlotForeign(WrenVM* vm, int slot)
   ASSERT(IS_FOREIGN(vm->apiStack[slot]),
          "Slot must hold a foreign instance.");
 
-  return AS_FOREIGN(vm->apiStack[slot])->data;
+  return wrenMemorySegmentData(AS_MEMORYSEGMENT(vm->apiStack[slot]));
 }
 
 const char* wrenGetSlotString(WrenVM* vm, int slot)
@@ -1754,10 +1754,10 @@ void* wrenSetSlotNewForeign(WrenVM* vm, int slot, int classSlot, size_t size)
   ObjClass* classObj = AS_CLASS(vm->apiStack[classSlot]);
   ASSERT(classObj->numFields == -1, "Class must be a foreign class.");
   
-  ObjForeign* foreign = wrenNewForeign(vm, classObj, size);
+  ObjMemorySegment* foreign = wrenNewForeign(vm, classObj, size);
   vm->apiStack[slot] = OBJ_VAL(foreign);
   
-  return (void*)foreign->data;
+  return (void*)wrenMemorySegmentData(foreign);
 }
 
 void wrenSetSlotNewList(WrenVM* vm, int slot)

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -505,7 +505,7 @@ static ObjClosure* compileInModule(WrenVM* vm, Value name, const char* source,
 // If successful, returns `null`. Otherwise, returns a string for the runtime
 // error message.
 static Value validateSuperclass(WrenVM* vm, Value name, Value superclassValue,
-                                int numFields)
+                                bool isForeign, int numFields)
 {
   // Make sure the superclass is a class.
   if (!IS_CLASS(superclassValue))
@@ -535,14 +535,14 @@ static Value validateSuperclass(WrenVM* vm, Value name, Value superclassValue,
         name, OBJ_VAL(superclass->name));
   }
 
-  if (superclass->numFields == -1)
+  if (superclass->isForeign)
   {
     return wrenStringFormat(vm,
         "Class '@' cannot inherit from foreign class '@'.",
         name, OBJ_VAL(superclass->name));
   }
 
-  if (numFields == -1 && superclass->numFields > 0)
+  if (isForeign && superclass->numFields > 0)
   {
     return wrenStringFormat(vm,
         "Foreign class '@' may not inherit from a class with fields.",
@@ -630,12 +630,12 @@ static void endClass(WrenVM* vm)
 
 // Creates a new class.
 //
-// If [numFields] is -1, the class is a foreign class. The name and superclass
-// should be on top of the fiber's stack. After calling this, the top of the
-// stack will contain the new class.
+// The name and superclass should be on top of the fiber's stack.
+// After calling this, the top of the stack will contain the new class.
 //
 // Aborts the current fiber if an error occurs.
-static void createClass(WrenVM* vm, int numFields, ObjModule* module)
+static void createClass(WrenVM* vm, bool isForeign, int numFields,
+                        ObjModule* module)
 {
   // Pull the name and superclass off the stack.
   Value name = vm->fiber->stackTop[-2];
@@ -645,20 +645,21 @@ static void createClass(WrenVM* vm, int numFields, ObjModule* module)
   // the other slot.
   vm->fiber->stackTop--;
 
-  vm->fiber->error = validateSuperclass(vm, name, superclass, numFields);
+  vm->fiber->error = validateSuperclass(vm, name, superclass, isForeign,
+                                        numFields);
   if (wrenHasError(vm->fiber)) return;
 
-  ObjClass* classObj = wrenNewClass(vm, AS_CLASS(superclass), numFields,
-                                    AS_STRING(name));
+  ObjClass* classObj = wrenNewClass(vm, AS_CLASS(superclass), isForeign,
+                                    numFields, AS_STRING(name));
   vm->fiber->stackTop[-1] = OBJ_VAL(classObj);
 
-  if (numFields == -1) bindForeignClass(vm, classObj, module);
+  if (isForeign) bindForeignClass(vm, classObj, module);
 }
 
 static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
 {
   ObjClass* classObj = AS_CLASS(stack[0]);
-  ASSERT(classObj->numFields == -1, "Class must be a foreign class.");
+  ASSERT(classObj->isForeign, "Class must be a foreign class.");
 
   // TODO: Don't look up every time.
   int symbol = wrenSymbolTableFind(&vm->methodNames, "<allocate>", 10);
@@ -1300,14 +1301,14 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
 
     CASE_CODE(CLASS):
     {
-      createClass(vm, READ_BYTE(), NULL);
+      createClass(vm, false, READ_BYTE(), NULL);
       if (wrenHasError(fiber)) RUNTIME_ERROR();
       DISPATCH();
     }
 
     CASE_CODE(FOREIGN_CLASS):
     {
-      createClass(vm, -1, fn->module);
+      createClass(vm, true, -1, fn->module);
       if (wrenHasError(fiber)) RUNTIME_ERROR();
       DISPATCH();
     }
@@ -1748,7 +1749,7 @@ void* wrenSetSlotNewForeign(WrenVM* vm, int slot, int classSlot, size_t size)
   ASSERT(IS_CLASS(vm->apiStack[classSlot]), "Slot must hold a class.");
   
   ObjClass* classObj = AS_CLASS(vm->apiStack[classSlot]);
-  ASSERT(classObj->numFields == -1, "Class must be a foreign class.");
+  ASSERT(classObj->isForeign, "Class must be a foreign class.");
   
   ObjMemorySegment* foreign = wrenNewForeign(vm, classObj, size);
   vm->apiStack[slot] = OBJ_VAL(foreign);

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -942,10 +942,9 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
     {
       uint8_t field = READ_BYTE();
       Value receiver = stackStart[0];
-      ASSERT(IS_INSTANCE(receiver), "Receiver should be instance.");
-      ObjInstance* instance = AS_INSTANCE(receiver);
-      ASSERT(field < instance->obj.classObj->numFields, "Out of bounds field.");
-      PUSH(instance->fields[field]);
+      ASSERT(IS_MEMORYSEGMENT(receiver), "Receiver should be a memory segment.");
+      ObjMemorySegment* ms = AS_MEMORYSEGMENT(receiver);
+      PUSH(*wrenMemorySegmentAt(ms, field));
       DISPATCH();
     }
 
@@ -1117,10 +1116,9 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
     {
       uint8_t field = READ_BYTE();
       Value receiver = stackStart[0];
-      ASSERT(IS_INSTANCE(receiver), "Receiver should be instance.");
-      ObjInstance* instance = AS_INSTANCE(receiver);
-      ASSERT(field < instance->obj.classObj->numFields, "Out of bounds field.");
-      instance->fields[field] = PEEK();
+      ASSERT(IS_MEMORYSEGMENT(receiver), "Receiver should be a memory segment.");
+      ObjMemorySegment* ms = AS_MEMORYSEGMENT(receiver);
+      *wrenMemorySegmentAt(ms, field) = PEEK();
       DISPATCH();
     }
 
@@ -1128,10 +1126,9 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
     {
       uint8_t field = READ_BYTE();
       Value receiver = POP();
-      ASSERT(IS_INSTANCE(receiver), "Receiver should be instance.");
-      ObjInstance* instance = AS_INSTANCE(receiver);
-      ASSERT(field < instance->obj.classObj->numFields, "Out of bounds field.");
-      PUSH(instance->fields[field]);
+      ASSERT(IS_MEMORYSEGMENT(receiver), "Receiver should be a memory segment.");
+      ObjMemorySegment* ms = AS_MEMORYSEGMENT(receiver);
+      PUSH(*wrenMemorySegmentAt(ms, field));
       DISPATCH();
     }
 
@@ -1139,10 +1136,9 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
     {
       uint8_t field = READ_BYTE();
       Value receiver = POP();
-      ASSERT(IS_INSTANCE(receiver), "Receiver should be instance.");
-      ObjInstance* instance = AS_INSTANCE(receiver);
-      ASSERT(field < instance->obj.classObj->numFields, "Out of bounds field.");
-      instance->fields[field] = PEEK();
+      ASSERT(IS_MEMORYSEGMENT(receiver), "Receiver should be a memory segment.");
+      ObjMemorySegment* ms = AS_MEMORYSEGMENT(receiver);
+      *wrenMemorySegmentAt(ms, field) = PEEK();
       DISPATCH();
     }
 

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1308,7 +1308,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
 
     CASE_CODE(FOREIGN_CLASS):
     {
-      createClass(vm, true, -1, fn->module);
+      createClass(vm, true, READ_BYTE(), fn->module);
       if (wrenHasError(fiber)) RUNTIME_ERROR();
       DISPATCH();
     }

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -132,7 +132,7 @@ struct WrenVM
 void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize);
 
 // Invoke the finalizer for the foreign object referenced by [foreign].
-void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign);
+void wrenFinalizeForeign(WrenVM* vm, ObjMemorySegment* foreign);
 
 // Creates a new [WrenHandle] for [value].
 WrenHandle* wrenMakeHandle(WrenVM* vm, Value value);

--- a/test/api/foreign_class.c
+++ b/test/api/foreign_class.c
@@ -4,6 +4,7 @@
 #include "foreign_class.h"
 
 static int finalized = 0;
+static int uid = 0;
 
 static void apiFinalized(WrenVM* vm)
 {
@@ -67,6 +68,11 @@ static void pointToString(WrenVM* vm)
   wrenSetSlotString(vm, 0, result);
 }
 
+static void resourceCreateUid(WrenVM* vm)
+{
+  wrenSetSlotDouble(vm, 0, uid++);
+}
+
 static void resourceAllocate(WrenVM* vm)
 {
   int* value = (int*)wrenSetSlotNewForeign(vm, 0, 0, sizeof(int));
@@ -96,6 +102,7 @@ WrenForeignMethodFn foreignClassBindMethod(const char* signature)
   if (strcmp(signature, "Counter.value") == 0) return counterValue;
   if (strcmp(signature, "Point.translate(_,_,_)") == 0) return pointTranslate;
   if (strcmp(signature, "Point.toString") == 0) return pointToString;
+  if (strcmp(signature, "static Resource.createUid") == 0) return resourceCreateUid;
 
   return NULL;
 }

--- a/test/api/foreign_class.c
+++ b/test/api/foreign_class.c
@@ -129,6 +129,13 @@ void foreignClassBindClass(
     return;
   }
 
+  if (strcmp(className, "TextureResource") == 0)
+  {
+    methods->allocate = resourceAllocate;
+    methods->finalize = resourceFinalize;
+    return;
+  }
+
   if (strcmp(className, "BadClass") == 0)
   {
     methods->allocate = badClassAllocate;

--- a/test/api/foreign_class.wren
+++ b/test/api/foreign_class.wren
@@ -54,7 +54,11 @@ System.print(error) // expect: Class 'Subclass' cannot inherit from foreign clas
 
 // Class with a finalizer.
 foreign class Resource {
-  construct new() {}
+  construct new() {
+    _uid = Resource.createUid
+  }
+  uid { _uid }
+  foreign static createUid
 }
 
 var resources = [
@@ -62,6 +66,13 @@ var resources = [
   Resource.new(),
   Resource.new()
 ]
+
+for (resource in resources) {
+  System.print("uid: %(resource.uid)")
+}
+// expect: uid: 0
+// expect: uid: 1
+// expect: uid: 2
 
 System.gc()
 System.print(ForeignClass.finalized) // expect: 0

--- a/test/api/foreign_class.wren
+++ b/test/api/foreign_class.wren
@@ -61,10 +61,17 @@ foreign class Resource {
   foreign static createUid
 }
 
+// Class subclassing a class.
+foreign class TextureResource is Resource {
+  construct new() {
+    super()
+  }
+}
+
 var resources = [
   Resource.new(),
   Resource.new(),
-  Resource.new()
+  TextureResource.new()
 ]
 
 for (resource in resources) {

--- a/test/language/class/field_in_foreign_class.wren
+++ b/test/language/class/field_in_foreign_class.wren
@@ -1,9 +1,0 @@
-foreign class Foo {
-  bar {
-    // Can't read a field.
-    System.print(_bar) // expect error
-
-    // Or write one.
-    _bar = "value" // expect error
-  }
-}


### PR DESCRIPTION
Before it can be applied, this patch set requires to solve the question of the behavior when inheriting from a foreign, when no constructor/destructor are provided, while the parent class had some.

This patch set allow foreign class to have member variables with some restrictions. It still must inherit from a regular class without member variables (should we check that there is no static member variables ?) or from another foreign class.

It does that by adding an `ObjMemorySegment` which is the fusion of `ObjForeign` and `ObjInstance`. The name comes from the fact that such object can technically be used hold any object the VM can produce, and therefore represent a memory segment of the VM.