### PR TITLE
Fix -Wall warnings

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3762,7 +3762,7 @@ ObjFn* wrenCompile(WrenVM* vm, ObjModule* module, const char* source,
   // Skip the UTF-8 BOM if there is one.
   if (strncmp(source, "\xEF\xBB\xBF", 3) == 0) source += 3;
   
-  Parser parser;
+  Parser parser = {};
   parser.vm = vm;
   parser.module = module;
   parser.source = source;

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -739,7 +739,6 @@ static Value importModule(WrenVM* vm, Value name)
   wrenPushRoot(vm, AS_OBJ(name));
 
   WrenLoadModuleResult result = {0};
-  const char* source = NULL;
   
   // Let the host try to provide the module.
   if (vm->config.loadModuleFn != NULL)


### PR DESCRIPTION
Removes two warnings I got when compiling with -Wall.  Fixes:

- Remove unused variable
- Zero-initialize main parser to avoid use before assignment.

Warnings were:

```
../../src/vm/wren_compiler.c: In function ‘wrenCompile’:
../../src/vm/wren_compiler.c:1050:20: warning: ‘parser.current’ is used uninitialized in this function [-Wuninitialized]
 1050 |   parser->previous = parser->current;
      |   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~

../../src/vm/wren_vm.c: In function ‘importModule’:
../../src/vm/wren_vm.c:742:15: warning: unused variable ‘source’ [-Wunused-variable]
  742 |   const char* source = NULL;
      |               ^~~~~~
```
