### PR TITLE
Add String.toLowerCase

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <stdio.h>
+
 #include "wren_common.h"
 #include "wren_core.h"
 #include "wren_math.h"
@@ -1161,6 +1163,23 @@ DEF_PRIMITIVE(string_startsWith)
   RETURN_BOOL(memcmp(string->value, search->value, search->length) == 0);
 }
 
+DEF_PRIMITIVE(string_toLowerCase)
+{
+  ObjString* string = AS_STRING(args[0]);
+
+  if (string->length == 0) {
+    RETURN_VAL(args[0]);
+  }
+
+  Value output = wrenNewStringLength(vm, &string->value[0], string->length);
+  char* str = (char*)AS_CSTRING(output);
+  for(int i = 0; str[i]; i++) {
+    str[i] = tolower(str[i]);
+  }
+
+  RETURN_VAL(output);
+}
+
 DEF_PRIMITIVE(string_plus)
 {
   if (!validateString(vm, args[1], "Right operand")) return false;
@@ -1425,6 +1444,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->stringClass, "iterateByte_(_)", string_iterateByte);
   PRIMITIVE(vm->stringClass, "iteratorValue(_)", string_iteratorValue);
   PRIMITIVE(vm->stringClass, "startsWith(_)", string_startsWith);
+  PRIMITIVE(vm->stringClass, "toLowerCase", string_toLowerCase);
   PRIMITIVE(vm->stringClass, "toString", string_toString);
 
   vm->listClass = AS_CLASS(wrenFindVariable(vm, coreModule, "List"));

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -5,8 +5,6 @@
 #include <string.h>
 #include <time.h>
 
-#include <stdio.h>
-
 #include "wren_common.h"
 #include "wren_core.h"
 #include "wren_math.h"

--- a/test/core/string/to_lower_case.wren
+++ b/test/core/string/to_lower_case.wren
@@ -1,0 +1,8 @@
+System.print("abc def ghi".toLowerCase) // expect: abc def ghi
+System.print("ABC DEF GHI".toLowerCase) // expect: abc def ghi
+System.print("AbC dEf GhI".toLowerCase) // expect: abc def ghi
+
+// Empty string
+System.print("".toLowerCase) // expect: ""
+
+System.print("ABC DEF GHI".toLowerCase is String) // expect: true


### PR DESCRIPTION
I've found I've been missing a few string methods, so would like to clean it up to give Strings a bit more power. This is a small start, with `.toLowerCase`, matching [JavaScript's](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) and [Java's](https://www.tutorialspoint.com/java/java_string_tolowercase.htm) toLowerCase() methods.

Wren's `.toLowerCase` method returns a lower-case representation of the String. This is accomplished using C's [`tolower()`](https://www.programiz.com/c-programming/library-function/ctype.h/tolower). Would like to add .toUpperCase, but wanted to get everyone's thoughts on this first.