### PR TITLE
Symbol table

### DIFF
--- a/src/optional/wren_opt_meta.c
+++ b/src/optional/wren_opt_meta.c
@@ -49,7 +49,7 @@ void metaGetModuleVariables(WrenVM* vm)
   }
     
   ObjModule* module = AS_MODULE(moduleValue);
-  ObjList* names = wrenNewList(vm, module->variableNames.count);
+  ObjList* names = wrenNewList(vm, module->variableNames.buffer.count);
   vm->apiStack[0] = OBJ_VAL(names);
 
   // Initialize the elements to null in case a collection happens when we
@@ -61,7 +61,7 @@ void metaGetModuleVariables(WrenVM* vm)
   
   for (int i = 0; i < names->elements.count; i++)
   {
-    names->elements.data[i] = OBJ_VAL(module->variableNames.data[i]);
+    names->elements.data[i] = OBJ_VAL(module->variableNames.buffer.data[i]);
   }
 }
 

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3612,7 +3612,7 @@ static void classDefinition(Compiler* compiler, bool isForeign)
   if (!isForeign)
   {
     compiler->fn->code.data[numFieldsInstruction] =
-        (uint8_t)classInfo.fields.count;
+        (uint8_t)classInfo.fields.buffer.count;
   }
   
   // Clear symbol tables for tracking field and method names.
@@ -3827,8 +3827,8 @@ ObjFn* wrenCompile(WrenVM* vm, ObjModule* module, const char* source,
     {
       // Synthesize a token for the original use site.
       parser.previous.type = TOKEN_NAME;
-      parser.previous.start = parser.module->variableNames.data[i]->value;
-      parser.previous.length = parser.module->variableNames.data[i]->length;
+      parser.previous.start = parser.module->variableNames.buffer.data[i]->value;
+      parser.previous.length = parser.module->variableNames.buffer.data[i]->length;
       parser.previous.line = (int)AS_NUM(parser.module->variables.data[i]);
       error(&compiler, "Variable is used but not defined.");
     }

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -159,7 +159,7 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int slot = READ_SHORT();
       printf("%-16s %5d '%s'\n", "LOAD_MODULE_VAR", slot,
-             fn->module->variableNames.data[slot]->value);
+             fn->module->variableNames.buffer.data[slot]->value);
       break;
     }
 
@@ -167,7 +167,7 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int slot = READ_SHORT();
       printf("%-16s %5d '%s'\n", "STORE_MODULE_VAR", slot,
-             fn->module->variableNames.data[slot]->value);
+             fn->module->variableNames.buffer.data[slot]->value);
       break;
     }
 
@@ -199,7 +199,7 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       int numArgs = bytecode[i - 1] - CODE_CALL_0;
       int symbol = READ_SHORT();
       printf("CALL_%-11d %5d '%s'\n", numArgs, symbol,
-             vm->methodNames.data[symbol]->value);
+             vm->methodNames.buffer.data[symbol]->value);
       break;
     }
 
@@ -225,7 +225,7 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       int symbol = READ_SHORT();
       int superclass = READ_SHORT();
       printf("SUPER_%-10d %5d '%s' %5d\n", numArgs, symbol,
-             vm->methodNames.data[symbol]->value, superclass);
+             vm->methodNames.buffer.data[symbol]->value, superclass);
       break;
     }
 
@@ -302,7 +302,7 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int symbol = READ_SHORT();
       printf("%-16s %5d '%s'\n", "METHOD_INSTANCE", symbol,
-             vm->methodNames.data[symbol]->value);
+             vm->methodNames.buffer.data[symbol]->value);
       break;
     }
 
@@ -310,7 +310,7 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int symbol = READ_SHORT();
       printf("%-16s %5d '%s'\n", "METHOD_STATIC", symbol,
-             vm->methodNames.data[symbol]->value);
+             vm->methodNames.buffer.data[symbol]->value);
       break;
     }
       

--- a/src/vm/wren_utils.c
+++ b/src/vm/wren_utils.c
@@ -9,12 +9,12 @@ DEFINE_BUFFER(String, ObjString*);
 
 void wrenSymbolTableInit(SymbolTable* symbols)
 {
-  wrenStringBufferInit(symbols);
+  wrenStringBufferInit(&symbols->buffer);
 }
 
 void wrenSymbolTableClear(WrenVM* vm, SymbolTable* symbols)
 {
-  wrenStringBufferClear(vm, symbols);
+  wrenStringBufferClear(vm, &symbols->buffer);
 }
 
 int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
@@ -23,10 +23,10 @@ int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
   ObjString* symbol = AS_STRING(wrenNewStringLength(vm, name, length));
   
   wrenPushRoot(vm, &symbol->obj);
-  wrenStringBufferWrite(vm, symbols, symbol);
+  wrenStringBufferWrite(vm, &symbols->buffer, symbol);
   wrenPopRoot(vm);
   
-  return symbols->count - 1;
+  return symbols->buffer.count - 1;
 }
 
 int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
@@ -45,9 +45,9 @@ int wrenSymbolTableFind(const SymbolTable* symbols,
 {
   // See if the symbol is already defined.
   // TODO: O(n). Do something better.
-  for (int i = 0; i < symbols->count; i++)
+  for (int i = 0; i < symbols->buffer.count; i++)
   {
-    if (wrenStringEqualsCString(symbols->data[i], name, length)) return i;
+    if (wrenStringEqualsCString(symbols->buffer.data[i], name, length)) return i;
   }
 
   return -1;
@@ -55,13 +55,13 @@ int wrenSymbolTableFind(const SymbolTable* symbols,
 
 void wrenBlackenSymbolTable(WrenVM* vm, SymbolTable* symbolTable)
 {
-  for (int i = 0; i < symbolTable->count; i++)
+  for (int i = 0; i < symbolTable->buffer.count; i++)
   {
-    wrenGrayObj(vm, &symbolTable->data[i]->obj);
+    wrenGrayObj(vm, &symbolTable->buffer.data[i]->obj);
   }
   
   // Keep track of how much memory is still in use.
-  vm->bytesAllocated += symbolTable->capacity * sizeof(*symbolTable->data);
+  vm->bytesAllocated += symbolTable->buffer.capacity * sizeof(*symbolTable->buffer.data);
 }
 
 int wrenUtf8EncodeNumBytes(int value)

--- a/src/vm/wren_utils.c
+++ b/src/vm/wren_utils.c
@@ -10,11 +10,22 @@ DEFINE_BUFFER(String, ObjString*);
 void wrenSymbolTableInit(SymbolTable* symbols)
 {
   wrenStringBufferInit(&symbols->buffer);
+  wrenIntBufferInit(&symbols->ordered);
 }
 
 void wrenSymbolTableClear(WrenVM* vm, SymbolTable* symbols)
 {
   wrenStringBufferClear(vm, &symbols->buffer);
+  wrenIntBufferClear(vm, &symbols->ordered);
+}
+
+static int wrenStringCompareCString(const ObjString* a,
+                                           const char* b, size_t length)
+{
+  int cmp = strncmp(a->value, b, length);
+
+  if (cmp != 0) return cmp;
+  return (int) a->length - (int) length;
 }
 
 int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
@@ -25,8 +36,19 @@ int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
   wrenPushRoot(vm, &symbol->obj);
   wrenStringBufferWrite(vm, &symbols->buffer, symbol);
   wrenPopRoot(vm);
-  
-  return symbols->buffer.count - 1;
+
+  int index = symbols->buffer.count - 1;
+  wrenIntBufferWrite(vm, &symbols->ordered, index);
+
+  int i = index - 1;
+
+  while (i >= 0 && wrenStringCompareCString(symbols->buffer.data[symbols->ordered.data[i]], name, length) > 0) {
+    symbols->ordered.data[i + 1] = symbols->ordered.data[i];
+    symbols->ordered.data[i] = index;
+    --i;
+  }
+
+  return index;
 }
 
 int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
@@ -44,10 +66,30 @@ int wrenSymbolTableFind(const SymbolTable* symbols,
                         const char* name, size_t length)
 {
   // See if the symbol is already defined.
-  // TODO: O(n). Do something better.
-  for (int i = 0; i < symbols->buffer.count; i++)
+  int lo = 0;
+  int hi = symbols->buffer.count;
+
+  while (lo < hi)
   {
-    if (wrenStringEqualsCString(symbols->buffer.data[i], name, length)) return i;
+    int mid = lo + (hi - lo) / 2;
+
+    ASSERT(mid < symbols->ordered.count, "");
+    ASSERT(symbols->ordered.data[mid] < symbols->buffer.count, "");
+
+    int cmp = wrenStringCompareCString(symbols->buffer.data[symbols->ordered.data[mid]], name, length);
+
+    if (cmp > 0)
+    {
+      hi = mid;
+    }
+    else if (cmp < 0)
+    {
+      lo = mid + 1;
+    }
+    else
+    {
+      return symbols->ordered.data[mid];
+    }
   }
 
   return -1;
@@ -62,6 +104,7 @@ void wrenBlackenSymbolTable(WrenVM* vm, SymbolTable* symbolTable)
   
   // Keep track of how much memory is still in use.
   vm->bytesAllocated += symbolTable->buffer.capacity * sizeof(*symbolTable->buffer.data);
+  vm->bytesAllocated += symbolTable->ordered.capacity * sizeof(*symbolTable->ordered.data);
 }
 
 int wrenUtf8EncodeNumBytes(int value)

--- a/src/vm/wren_utils.c
+++ b/src/vm/wren_utils.c
@@ -3,6 +3,8 @@
 #include "wren_utils.h"
 #include "wren_vm.h"
 
+#define SYMBOL_TABLE_FIND_THRESHOLD 15
+
 DEFINE_BUFFER(Byte, uint8_t);
 DEFINE_BUFFER(Int, int);
 DEFINE_BUFFER(String, ObjString*);
@@ -66,6 +68,17 @@ int wrenSymbolTableFind(const SymbolTable* symbols,
                         const char* name, size_t length)
 {
   // See if the symbol is already defined.
+
+  if (symbols->buffer.count < SYMBOL_TABLE_FIND_THRESHOLD)
+  {
+    for (int i = 0; i < symbols->buffer.count; i++)
+    {
+      if (wrenStringEqualsCString(symbols->buffer.data[i], name, length)) return i;
+    }
+
+    return -1;
+  }
+
   int lo = 0;
   int hi = symbols->buffer.count;
 

--- a/src/vm/wren_utils.h
+++ b/src/vm/wren_utils.h
@@ -67,8 +67,9 @@ DECLARE_BUFFER(Byte, uint8_t);
 DECLARE_BUFFER(Int, int);
 DECLARE_BUFFER(String, ObjString*);
 
-// TODO: Change this to use a map.
-typedef StringBuffer SymbolTable;
+typedef struct {
+  StringBuffer buffer;
+} SymbolTable;
 
 // Initializes the symbol table.
 void wrenSymbolTableInit(SymbolTable* symbols);

--- a/src/vm/wren_utils.h
+++ b/src/vm/wren_utils.h
@@ -69,6 +69,7 @@ DECLARE_BUFFER(String, ObjString*);
 
 typedef struct {
   StringBuffer buffer;
+  IntBuffer ordered;
 } SymbolTable;
 
 // Initializes the symbol table.

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -98,7 +98,7 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
 
 void wrenFreeVM(WrenVM* vm)
 {
-  ASSERT(vm->methodNames.count > 0, "VM appears to have already been freed.");
+  ASSERT(vm->methodNames.buffer.count > 0, "VM appears to have already been freed.");
   
   // Free all of the GC objects.
   Obj* obj = vm->first;

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -438,7 +438,7 @@ static void runtimeError(WrenVM* vm)
 static void methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
 {
   vm->fiber->error = wrenStringFormat(vm, "@ does not implement '$'.",
-      OBJ_VAL(classObj->name), vm->methodNames.data[symbol]->value);
+      OBJ_VAL(classObj->name), vm->methodNames.buffer.data[symbol]->value);
 }
 
 // Looks up the previously loaded module with [name].
@@ -475,8 +475,8 @@ static ObjClosure* compileInModule(WrenVM* vm, Value name, const char* source,
     for (int i = 0; i < coreModule->variables.count; i++)
     {
       wrenDefineVariable(vm, module,
-                         coreModule->variableNames.data[i]->value,
-                         coreModule->variableNames.data[i]->length,
+                         coreModule->variableNames.buffer.data[i]->value,
+                         coreModule->variableNames.buffer.data[i]->length,
                          coreModule->variables.data[i], NULL);
     }
   }


### PR DESCRIPTION
It was a TODO in `wrenSymbolTableFind`: "TODO: O(n). Do something better.". Here is something better in O(log n) thanks to a binary search.

A constraint was to keep the current `StringBuffer` as the symbols are identified by an index in this buffer. So I added a second buffer where the strings are indirectly ordered. During `wrenSymbolTableFind`, this second table is used with a binary search, if there is enough elements to outperform linear search (currently 15, which gives good performance, see below).

Some figures:

```
api_call - wren                .......... 0.05s 0.0022 103.28% relative to baseline
api_foreign_method - wren      .......... 0.25s 0.0034 101.57% relative to baseline
binary_trees - wren            .......... 0.18s 0.0137  97.74% relative to baseline
binary_trees_gc - wren         .......... 0.83s 0.0105 111.33% relative to baseline
delta_blue - wren              .......... 0.11s 0.0085 102.33% relative to baseline
fib - wren                     .......... 0.18s 0.0050 101.50% relative to baseline
fibers - wren                  .......... 0.03s 0.0025 101.82% relative to baseline
for - wren                     .......... 0.06s 0.0010 101.75% relative to baseline
method_call - wren             .......... 0.10s 0.0007 100.28% relative to baseline
map_numeric - wren             .......... 1.03s 0.0116 100.73% relative to baseline
map_string - wren              .......... 0.12s 0.0021 108.19% relative to baseline
string_equals - wren           .......... 0.15s 0.0237 100.77% relative to baseline
```
This new function performs well with `binary_tree_gc` because `System.gc` is one of the last method defined in `wren_core.c`, so the symbol `gc` is at the end of the symbol table of the module (175 out of 177 symbols). The linear search has to go through all the symbols whereas the binary search finds it in roughly 7 or 8 comparisons.
