### PR TITLE
Clean up functions in header vs source files

### DIFF
--- a/projects/make.bsd/wren.make
+++ b/projects/make.bsd/wren.make
@@ -87,8 +87,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -98,11 +96,23 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_math.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/wren_compiler.o
 OBJECTS += $(OBJDIR)/wren_core.o
 OBJECTS += $(OBJDIR)/wren_debug.o
+OBJECTS += $(OBJDIR)/wren_math.o
 OBJECTS += $(OBJDIR)/wren_opt_meta.o
 OBJECTS += $(OBJDIR)/wren_opt_random.o
 OBJECTS += $(OBJDIR)/wren_primitive.o
@@ -116,7 +126,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren
 	$(SILENT) $(LINKCMD)
@@ -142,9 +152,11 @@ clean:
 	@echo Cleaning wren
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
@@ -183,6 +195,9 @@ $(OBJDIR)/wren_core.o: ../../src/vm/wren_core.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_debug.o: ../../src/vm/wren_debug.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/wren_math.o: ../../src/vm/wren_math.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_primitive.o: ../../src/vm/wren_primitive.c

--- a/projects/make.bsd/wren_shared.make
+++ b/projects/make.bsd/wren_shared.make
@@ -87,8 +87,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -shared
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -98,11 +96,23 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_math.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/wren_compiler.o
 OBJECTS += $(OBJDIR)/wren_core.o
 OBJECTS += $(OBJDIR)/wren_debug.o
+OBJECTS += $(OBJDIR)/wren_math.o
 OBJECTS += $(OBJDIR)/wren_opt_meta.o
 OBJECTS += $(OBJDIR)/wren_opt_random.o
 OBJECTS += $(OBJDIR)/wren_primitive.o
@@ -116,7 +126,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_shared
 	$(SILENT) $(LINKCMD)
@@ -142,9 +152,11 @@ clean:
 	@echo Cleaning wren_shared
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
@@ -183,6 +195,9 @@ $(OBJDIR)/wren_core.o: ../../src/vm/wren_core.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_debug.o: ../../src/vm/wren_debug.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/wren_math.o: ../../src/vm/wren_math.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_primitive.o: ../../src/vm/wren_primitive.c

--- a/projects/make.bsd/wren_test.make
+++ b/projects/make.bsd/wren_test.make
@@ -97,8 +97,6 @@ LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -108,8 +106,28 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/api_tests.o
+GENERATED += $(OBJDIR)/benchmark.o
+GENERATED += $(OBJDIR)/call.o
+GENERATED += $(OBJDIR)/call_calls_foreign.o
+GENERATED += $(OBJDIR)/call_wren_call_root.o
+GENERATED += $(OBJDIR)/error.o
+GENERATED += $(OBJDIR)/foreign_class.o
+GENERATED += $(OBJDIR)/get_variable.o
+GENERATED += $(OBJDIR)/handle.o
+GENERATED += $(OBJDIR)/lists.o
+GENERATED += $(OBJDIR)/main.o
+GENERATED += $(OBJDIR)/maps.o
+GENERATED += $(OBJDIR)/new_vm.o
+GENERATED += $(OBJDIR)/reset_stack_after_call_abort.o
+GENERATED += $(OBJDIR)/reset_stack_after_foreign_construct.o
+GENERATED += $(OBJDIR)/resolution.o
+GENERATED += $(OBJDIR)/slots.o
+GENERATED += $(OBJDIR)/test.o
+GENERATED += $(OBJDIR)/user_data.o
 OBJECTS += $(OBJDIR)/api_tests.o
 OBJECTS += $(OBJDIR)/benchmark.o
 OBJECTS += $(OBJDIR)/call.o
@@ -136,7 +154,7 @@ OBJECTS += $(OBJDIR)/user_data.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_test
 	$(SILENT) $(LINKCMD)
@@ -162,9 +180,11 @@ clean:
 	@echo Cleaning wren_test
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 

--- a/projects/make.mac/wren.make
+++ b/projects/make.mac/wren.make
@@ -95,8 +95,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -106,11 +104,23 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_math.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/wren_compiler.o
 OBJECTS += $(OBJDIR)/wren_core.o
 OBJECTS += $(OBJDIR)/wren_debug.o
+OBJECTS += $(OBJDIR)/wren_math.o
 OBJECTS += $(OBJDIR)/wren_opt_meta.o
 OBJECTS += $(OBJDIR)/wren_opt_random.o
 OBJECTS += $(OBJDIR)/wren_primitive.o
@@ -124,7 +134,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren
 	$(SILENT) $(LINKCMD)
@@ -150,9 +160,11 @@ clean:
 	@echo Cleaning wren
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
@@ -191,6 +203,9 @@ $(OBJDIR)/wren_core.o: ../../src/vm/wren_core.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_debug.o: ../../src/vm/wren_debug.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/wren_math.o: ../../src/vm/wren_math.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_primitive.o: ../../src/vm/wren_primitive.c

--- a/projects/make.mac/wren_shared.make
+++ b/projects/make.mac/wren_shared.make
@@ -95,8 +95,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -dynamiclib -Wl,-install_name,@rpath/libwren_d.dylib
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -106,11 +104,23 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_math.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/wren_compiler.o
 OBJECTS += $(OBJDIR)/wren_core.o
 OBJECTS += $(OBJDIR)/wren_debug.o
+OBJECTS += $(OBJDIR)/wren_math.o
 OBJECTS += $(OBJDIR)/wren_opt_meta.o
 OBJECTS += $(OBJDIR)/wren_opt_random.o
 OBJECTS += $(OBJDIR)/wren_primitive.o
@@ -124,7 +134,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_shared
 	$(SILENT) $(LINKCMD)
@@ -150,9 +160,11 @@ clean:
 	@echo Cleaning wren_shared
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
@@ -191,6 +203,9 @@ $(OBJDIR)/wren_core.o: ../../src/vm/wren_core.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_debug.o: ../../src/vm/wren_debug.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/wren_math.o: ../../src/vm/wren_math.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_primitive.o: ../../src/vm/wren_primitive.c

--- a/projects/make.mac/wren_test.make
+++ b/projects/make.mac/wren_test.make
@@ -105,8 +105,6 @@ LIBS += ../../lib/libwren_d.a
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -116,8 +114,28 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/api_tests.o
+GENERATED += $(OBJDIR)/benchmark.o
+GENERATED += $(OBJDIR)/call.o
+GENERATED += $(OBJDIR)/call_calls_foreign.o
+GENERATED += $(OBJDIR)/call_wren_call_root.o
+GENERATED += $(OBJDIR)/error.o
+GENERATED += $(OBJDIR)/foreign_class.o
+GENERATED += $(OBJDIR)/get_variable.o
+GENERATED += $(OBJDIR)/handle.o
+GENERATED += $(OBJDIR)/lists.o
+GENERATED += $(OBJDIR)/main.o
+GENERATED += $(OBJDIR)/maps.o
+GENERATED += $(OBJDIR)/new_vm.o
+GENERATED += $(OBJDIR)/reset_stack_after_call_abort.o
+GENERATED += $(OBJDIR)/reset_stack_after_foreign_construct.o
+GENERATED += $(OBJDIR)/resolution.o
+GENERATED += $(OBJDIR)/slots.o
+GENERATED += $(OBJDIR)/test.o
+GENERATED += $(OBJDIR)/user_data.o
 OBJECTS += $(OBJDIR)/api_tests.o
 OBJECTS += $(OBJDIR)/benchmark.o
 OBJECTS += $(OBJDIR)/call.o
@@ -144,7 +162,7 @@ OBJECTS += $(OBJDIR)/user_data.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_test
 	$(SILENT) $(LINKCMD)
@@ -170,9 +188,11 @@ clean:
 	@echo Cleaning wren_test
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 

--- a/projects/make/wren.make
+++ b/projects/make/wren.make
@@ -87,8 +87,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -98,11 +96,23 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_math.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/wren_compiler.o
 OBJECTS += $(OBJDIR)/wren_core.o
 OBJECTS += $(OBJDIR)/wren_debug.o
+OBJECTS += $(OBJDIR)/wren_math.o
 OBJECTS += $(OBJDIR)/wren_opt_meta.o
 OBJECTS += $(OBJDIR)/wren_opt_random.o
 OBJECTS += $(OBJDIR)/wren_primitive.o
@@ -116,7 +126,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren
 	$(SILENT) $(LINKCMD)
@@ -142,9 +152,11 @@ clean:
 	@echo Cleaning wren
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
@@ -183,6 +195,9 @@ $(OBJDIR)/wren_core.o: ../../src/vm/wren_core.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_debug.o: ../../src/vm/wren_debug.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/wren_math.o: ../../src/vm/wren_math.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_primitive.o: ../../src/vm/wren_primitive.c

--- a/projects/make/wren_shared.make
+++ b/projects/make/wren_shared.make
@@ -87,8 +87,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -shared -Wl,-soname=libwren_d.so
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -98,11 +96,23 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_math.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/wren_compiler.o
 OBJECTS += $(OBJDIR)/wren_core.o
 OBJECTS += $(OBJDIR)/wren_debug.o
+OBJECTS += $(OBJDIR)/wren_math.o
 OBJECTS += $(OBJDIR)/wren_opt_meta.o
 OBJECTS += $(OBJDIR)/wren_opt_random.o
 OBJECTS += $(OBJDIR)/wren_primitive.o
@@ -116,7 +126,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_shared
 	$(SILENT) $(LINKCMD)
@@ -142,9 +152,11 @@ clean:
 	@echo Cleaning wren_shared
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
@@ -183,6 +195,9 @@ $(OBJDIR)/wren_core.o: ../../src/vm/wren_core.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_debug.o: ../../src/vm/wren_debug.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/wren_math.o: ../../src/vm/wren_math.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/wren_primitive.o: ../../src/vm/wren_primitive.c

--- a/projects/make/wren_test.make
+++ b/projects/make/wren_test.make
@@ -97,8 +97,6 @@ LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -108,8 +106,28 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/api_tests.o
+GENERATED += $(OBJDIR)/benchmark.o
+GENERATED += $(OBJDIR)/call.o
+GENERATED += $(OBJDIR)/call_calls_foreign.o
+GENERATED += $(OBJDIR)/call_wren_call_root.o
+GENERATED += $(OBJDIR)/error.o
+GENERATED += $(OBJDIR)/foreign_class.o
+GENERATED += $(OBJDIR)/get_variable.o
+GENERATED += $(OBJDIR)/handle.o
+GENERATED += $(OBJDIR)/lists.o
+GENERATED += $(OBJDIR)/main.o
+GENERATED += $(OBJDIR)/maps.o
+GENERATED += $(OBJDIR)/new_vm.o
+GENERATED += $(OBJDIR)/reset_stack_after_call_abort.o
+GENERATED += $(OBJDIR)/reset_stack_after_foreign_construct.o
+GENERATED += $(OBJDIR)/resolution.o
+GENERATED += $(OBJDIR)/slots.o
+GENERATED += $(OBJDIR)/test.o
+GENERATED += $(OBJDIR)/user_data.o
 OBJECTS += $(OBJDIR)/api_tests.o
 OBJECTS += $(OBJDIR)/benchmark.o
 OBJECTS += $(OBJDIR)/call.o
@@ -136,7 +154,7 @@ OBJECTS += $(OBJDIR)/user_data.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_test
 	$(SILENT) $(LINKCMD)
@@ -162,9 +180,11 @@ clean:
 	@echo Cleaning wren_test
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 

--- a/projects/vs2017/wren.vcxproj
+++ b/projects/vs2017/wren.vcxproj
@@ -55,7 +55,8 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">
@@ -256,6 +257,7 @@
     <ClInclude Include="..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\src\vm\wren_debug.h" />
+    <ClInclude Include="..\..\src\vm\wren_math.h" />
     <ClInclude Include="..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\src\vm\wren_utils.h" />
@@ -268,6 +270,7 @@
     <ClCompile Include="..\..\src\vm\wren_compiler.c" />
     <ClCompile Include="..\..\src\vm\wren_core.c" />
     <ClCompile Include="..\..\src\vm\wren_debug.c" />
+    <ClCompile Include="..\..\src\vm\wren_math.c" />
     <ClCompile Include="..\..\src\vm\wren_primitive.c" />
     <ClCompile Include="..\..\src\vm\wren_utils.c" />
     <ClCompile Include="..\..\src\vm\wren_value.c" />

--- a/projects/vs2017/wren.vcxproj.filters
+++ b/projects/vs2017/wren.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="..\..\src\vm\wren_debug.h">
       <Filter>vm</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\vm\wren_math.h">
+      <Filter>vm</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\vm\wren_opcodes.h">
       <Filter>vm</Filter>
     </ClInclude>
@@ -63,6 +66,9 @@
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_debug.c">
+      <Filter>vm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\vm\wren_math.c">
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_primitive.c">

--- a/projects/vs2017/wren_shared.vcxproj
+++ b/projects/vs2017/wren_shared.vcxproj
@@ -55,7 +55,8 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren_shared</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">
@@ -268,6 +269,7 @@
     <ClInclude Include="..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\src\vm\wren_debug.h" />
+    <ClInclude Include="..\..\src\vm\wren_math.h" />
     <ClInclude Include="..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\src\vm\wren_utils.h" />
@@ -280,6 +282,7 @@
     <ClCompile Include="..\..\src\vm\wren_compiler.c" />
     <ClCompile Include="..\..\src\vm\wren_core.c" />
     <ClCompile Include="..\..\src\vm\wren_debug.c" />
+    <ClCompile Include="..\..\src\vm\wren_math.c" />
     <ClCompile Include="..\..\src\vm\wren_primitive.c" />
     <ClCompile Include="..\..\src\vm\wren_utils.c" />
     <ClCompile Include="..\..\src\vm\wren_value.c" />

--- a/projects/vs2017/wren_shared.vcxproj.filters
+++ b/projects/vs2017/wren_shared.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="..\..\src\vm\wren_debug.h">
       <Filter>vm</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\vm\wren_math.h">
+      <Filter>vm</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\vm\wren_opcodes.h">
       <Filter>vm</Filter>
     </ClInclude>
@@ -63,6 +66,9 @@
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_debug.c">
+      <Filter>vm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\vm\wren_math.c">
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_primitive.c">

--- a/projects/vs2017/wren_test.vcxproj
+++ b/projects/vs2017/wren_test.vcxproj
@@ -55,7 +55,8 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren_test</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">

--- a/projects/vs2019/wren.sln
+++ b/projects/vs2019/wren.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 16
+# Visual Studio Version 16
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wren_test", "wren_test.vcxproj", "{60BC8FB3-CC26-442A-1565-F5CF810E227F}"
 	ProjectSection(ProjectDependencies) = postProject
 		{0143A07C-ED79-A10D-9666-8710827C1D0F} = {0143A07C-ED79-A10D-9666-8710827C1D0F}

--- a/projects/vs2019/wren.vcxproj
+++ b/projects/vs2019/wren.vcxproj
@@ -256,6 +256,7 @@
     <ClInclude Include="..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\src\vm\wren_debug.h" />
+    <ClInclude Include="..\..\src\vm\wren_math.h" />
     <ClInclude Include="..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\src\vm\wren_utils.h" />
@@ -268,6 +269,7 @@
     <ClCompile Include="..\..\src\vm\wren_compiler.c" />
     <ClCompile Include="..\..\src\vm\wren_core.c" />
     <ClCompile Include="..\..\src\vm\wren_debug.c" />
+    <ClCompile Include="..\..\src\vm\wren_math.c" />
     <ClCompile Include="..\..\src\vm\wren_primitive.c" />
     <ClCompile Include="..\..\src\vm\wren_utils.c" />
     <ClCompile Include="..\..\src\vm\wren_value.c" />

--- a/projects/vs2019/wren.vcxproj.filters
+++ b/projects/vs2019/wren.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="..\..\src\vm\wren_debug.h">
       <Filter>vm</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\vm\wren_math.h">
+      <Filter>vm</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\vm\wren_opcodes.h">
       <Filter>vm</Filter>
     </ClInclude>
@@ -63,6 +66,9 @@
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_debug.c">
+      <Filter>vm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\vm\wren_math.c">
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_primitive.c">

--- a/projects/vs2019/wren_shared.vcxproj
+++ b/projects/vs2019/wren_shared.vcxproj
@@ -268,6 +268,7 @@
     <ClInclude Include="..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\src\vm\wren_debug.h" />
+    <ClInclude Include="..\..\src\vm\wren_math.h" />
     <ClInclude Include="..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\src\vm\wren_utils.h" />
@@ -280,6 +281,7 @@
     <ClCompile Include="..\..\src\vm\wren_compiler.c" />
     <ClCompile Include="..\..\src\vm\wren_core.c" />
     <ClCompile Include="..\..\src\vm\wren_debug.c" />
+    <ClCompile Include="..\..\src\vm\wren_math.c" />
     <ClCompile Include="..\..\src\vm\wren_primitive.c" />
     <ClCompile Include="..\..\src\vm\wren_utils.c" />
     <ClCompile Include="..\..\src\vm\wren_value.c" />

--- a/projects/vs2019/wren_shared.vcxproj.filters
+++ b/projects/vs2019/wren_shared.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="..\..\src\vm\wren_debug.h">
       <Filter>vm</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\vm\wren_math.h">
+      <Filter>vm</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\vm\wren_opcodes.h">
       <Filter>vm</Filter>
     </ClInclude>
@@ -63,6 +66,9 @@
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_debug.c">
+      <Filter>vm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\vm\wren_math.c">
       <Filter>vm</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\vm\wren_primitive.c">

--- a/projects/xcode/wren.xcodeproj/project.pbxproj
+++ b/projects/xcode/wren.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */ = {isa = PBXBuildFile; fileRef = A24154A4F8CEBF16D147D2E4 /* wren_core.c */; };
 		D1029E9FB01FB8D18C2914DF /* wren_opt_meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 62592227F4E6EC195DBF9067 /* wren_opt_meta.c */; };
 		E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */ = {isa = PBXBuildFile; fileRef = AD30296CDCC1F85EB7CF37AC /* wren_value.c */; };
+		F8DA42FE2AD38DB0A4B2C93E /* wren_math.c in Sources */ = {isa = PBXBuildFile; fileRef = 97564566EDE3AFD8C65CC3A6 /* wren_math.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,7 +30,9 @@
 		6F616124E0840216964AAF64 /* wren_primitive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_primitive.c; path = ../../src/vm/wren_primitive.c; sourceTree = "<group>"; };
 		737815DBCADD88CD7CEBA41B /* wren_opt_random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_random.c; path = ../../src/optional/wren_opt_random.c; sourceTree = "<group>"; };
 		7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opcodes.h; path = ../../src/vm/wren_opcodes.h; sourceTree = "<group>"; };
+		80BCD9B0D74A4422AFC357F0 /* wren_math.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_math.h; path = ../../src/vm/wren_math.h; sourceTree = "<group>"; };
 		8BA7E8EEE2355360BAAE672E /* wren_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_core.h; path = ../../src/vm/wren_core.h; sourceTree = "<group>"; };
+		97564566EDE3AFD8C65CC3A6 /* wren_math.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_math.c; path = ../../src/vm/wren_math.c; sourceTree = "<group>"; };
 		A24154A4F8CEBF16D147D2E4 /* wren_core.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_core.c; path = ../../src/vm/wren_core.c; sourceTree = "<group>"; };
 		A5CED894D560A786B06DE6D4 /* wren_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_utils.c; path = ../../src/vm/wren_utils.c; sourceTree = "<group>"; };
 		AAEE79A50253EC97B46207E5 /* wren_opt_random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_random.h; path = ../../src/optional/wren_opt_random.h; sourceTree = "<group>"; };
@@ -94,6 +97,8 @@
 				8BA7E8EEE2355360BAAE672E /* wren_core.h */,
 				39C26800695436F244617640 /* wren_debug.c */,
 				44AC34EA743E03DC4F4B432A /* wren_debug.h */,
+				97564566EDE3AFD8C65CC3A6 /* wren_math.c */,
+				80BCD9B0D74A4422AFC357F0 /* wren_math.h */,
 				7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */,
 				6F616124E0840216964AAF64 /* wren_primitive.c */,
 				FCC7D88E6DEA798023B126CE /* wren_primitive.h */,
@@ -172,6 +177,7 @@
 				76585F8088823C32BC7325C0 /* wren_compiler.c in Sources */,
 				B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */,
 				20773D38B5EDFC6A248A5378 /* wren_debug.c in Sources */,
+				F8DA42FE2AD38DB0A4B2C93E /* wren_math.c in Sources */,
 				76CC0A9CBADFDBCEAEB160DC /* wren_primitive.c in Sources */,
 				8D5FBD0C22D67C3E9172D34C /* wren_utils.c in Sources */,
 				E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */,

--- a/projects/xcode/wren_shared.xcodeproj/project.pbxproj
+++ b/projects/xcode/wren_shared.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */ = {isa = PBXBuildFile; fileRef = A24154A4F8CEBF16D147D2E4 /* wren_core.c */; };
 		D1029E9FB01FB8D18C2914DF /* wren_opt_meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 62592227F4E6EC195DBF9067 /* wren_opt_meta.c */; };
 		E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */ = {isa = PBXBuildFile; fileRef = AD30296CDCC1F85EB7CF37AC /* wren_value.c */; };
+		F8DA42FE2AD38DB0A4B2C93E /* wren_math.c in Sources */ = {isa = PBXBuildFile; fileRef = 97564566EDE3AFD8C65CC3A6 /* wren_math.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,8 +29,10 @@
 		6F616124E0840216964AAF64 /* wren_primitive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_primitive.c; path = ../../src/vm/wren_primitive.c; sourceTree = "<group>"; };
 		737815DBCADD88CD7CEBA41B /* wren_opt_random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_random.c; path = ../../src/optional/wren_opt_random.c; sourceTree = "<group>"; };
 		7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opcodes.h; path = ../../src/vm/wren_opcodes.h; sourceTree = "<group>"; };
+		80BCD9B0D74A4422AFC357F0 /* wren_math.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_math.h; path = ../../src/vm/wren_math.h; sourceTree = "<group>"; };
 		89E69C5EA0F937909115329E /* libwren.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libwren.dylib; path = libwren.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BA7E8EEE2355360BAAE672E /* wren_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_core.h; path = ../../src/vm/wren_core.h; sourceTree = "<group>"; };
+		97564566EDE3AFD8C65CC3A6 /* wren_math.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_math.c; path = ../../src/vm/wren_math.c; sourceTree = "<group>"; };
 		A24154A4F8CEBF16D147D2E4 /* wren_core.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_core.c; path = ../../src/vm/wren_core.c; sourceTree = "<group>"; };
 		A5CED894D560A786B06DE6D4 /* wren_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_utils.c; path = ../../src/vm/wren_utils.c; sourceTree = "<group>"; };
 		AAEE79A50253EC97B46207E5 /* wren_opt_random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_random.h; path = ../../src/optional/wren_opt_random.h; sourceTree = "<group>"; };
@@ -83,6 +86,8 @@
 				8BA7E8EEE2355360BAAE672E /* wren_core.h */,
 				39C26800695436F244617640 /* wren_debug.c */,
 				44AC34EA743E03DC4F4B432A /* wren_debug.h */,
+				97564566EDE3AFD8C65CC3A6 /* wren_math.c */,
+				80BCD9B0D74A4422AFC357F0 /* wren_math.h */,
 				7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */,
 				6F616124E0840216964AAF64 /* wren_primitive.c */,
 				FCC7D88E6DEA798023B126CE /* wren_primitive.h */,
@@ -172,6 +177,7 @@
 				76585F8088823C32BC7325C0 /* wren_compiler.c in Sources */,
 				B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */,
 				20773D38B5EDFC6A248A5378 /* wren_debug.c in Sources */,
+				F8DA42FE2AD38DB0A4B2C93E /* wren_math.c in Sources */,
 				76CC0A9CBADFDBCEAEB160DC /* wren_primitive.c in Sources */,
 				8D5FBD0C22D67C3E9172D34C /* wren_utils.c in Sources */,
 				E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */,

--- a/src/vm/wren_math.c
+++ b/src/vm/wren_math.c
@@ -1,0 +1,15 @@
+#include "wren_math.h"
+
+inline double wrenDoubleFromBits(uint64_t bits)
+{
+  WrenDoubleBits data;
+  data.bits64 = bits;
+  return data.num;
+}
+
+inline uint64_t wrenDoubleToBits(double num)
+{
+  WrenDoubleBits data;
+  data.num = num;
+  return data.bits64;
+}

--- a/src/vm/wren_math.h
+++ b/src/vm/wren_math.h
@@ -17,18 +17,8 @@ typedef union
 
 #define WREN_DOUBLE_NAN (wrenDoubleFromBits(WREN_DOUBLE_QNAN_POS_MIN_BITS))
 
-static inline double wrenDoubleFromBits(uint64_t bits)
-{
-  WrenDoubleBits data;
-  data.bits64 = bits;
-  return data.num;
-}
+double wrenDoubleFromBits(uint64_t bits);
 
-static inline uint64_t wrenDoubleToBits(double num)
-{
-  WrenDoubleBits data;
-  data.num = num;
-  return data.bits64;
-}
+uint64_t wrenDoubleToBits(double num);
 
 #endif

--- a/src/vm/wren_primitive.c
+++ b/src/vm/wren_primitive.c
@@ -1,4 +1,5 @@
 #include "wren_primitive.h"
+#include "wren_value.h"
 
 #include <math.h>
 

--- a/util/generate_amalgamation.py
+++ b/util/generate_amalgamation.py
@@ -4,7 +4,6 @@ import sys
 from os.path import basename, dirname, join, realpath, isfile
 from glob import iglob
 import re
-from typing import TYPE_CHECKING
 
 WREN_IMPLEMENTATION = 'WREN_IMPLEMENTATION'
 INCLUDE_PATTERN = re.compile(r'^\s*#include "([\w.]+)"')

--- a/util/generate_amalgamation.py
+++ b/util/generate_amalgamation.py
@@ -4,7 +4,9 @@ import sys
 from os.path import basename, dirname, join, realpath, isfile
 from glob import iglob
 import re
+from typing import TYPE_CHECKING
 
+WREN_IMPLEMENTATION = 'WREN_IMPLEMENTATION'
 INCLUDE_PATTERN = re.compile(r'^\s*#include "([\w.]+)"')
 GUARD_PATTERN = re.compile(r'^#ifndef wren(_\w+)?_h$')
 WREN_DIR = dirname(dirname(realpath(__file__)))
@@ -40,6 +42,8 @@ def add_file(filename):
   once = False
 
   out.write('// Begin file "{0}"\n'.format(bname))
+  if bname.endswith('.c'):
+    out.write('#ifdef {0}\n'.format(WREN_IMPLEMENTATION))
   with open(filename, 'r') as f:
     for line in f:
       m = INCLUDE_PATTERN.match(line)
@@ -49,6 +53,8 @@ def add_file(filename):
         out.write(line)
       if GUARD_PATTERN.match(line):
         once = True
+  if bname.endswith('.c'):
+    out.write('\n#endif // {0}\n'.format(WREN_IMPLEMENTATION))
   out.write('// End file "{0}"\n'.format(bname))
 
   # Only skip header files which use #ifndef guards.


### PR DESCRIPTION
This cleans up the static declarations of functions that are used outside of their own source files by having the declaration in the .h file, and the definition in the .c file. In turn, this enables the ability to use `WREN_IMPLEMENTATION` in the amalgamated wren.h file.

Fixes #1030
