### PR TITLE
fix: stack smaching with long names

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -48,7 +48,7 @@
 // is kind of hairy, but fortunately we can control what the longest possible
 // message is and handle that. Ideally, we'd use `snprintf()`, but that's not
 // available in standard C++98.
-#define ERROR_MESSAGE_SIZE (80 + MAX_VARIABLE_NAME + 15)
+#define ERROR_MESSAGE_SIZE (80 + MAX_VARIABLE_NAME + MAX_VARIABLE_NAME + 15)
 
 typedef enum
 {
@@ -3331,12 +3331,18 @@ static int declareMethod(Compiler* compiler, Signature* signature,
     if (methods->data[i] == symbol)
     {
       const char* staticPrefix = classInfo->inStatic ? "static " : "";
-      error(compiler, "Class %s already defines a %smethod '%s'.",
+      if (compiler->enclosingClass->name->length > MAX_VARIABLE_NAME) {
+        error(compiler, "Class %.*s... already defines a %smethod '%s'.",
+          MAX_VARIABLE_NAME,
+          &compiler->enclosingClass->name->value, staticPrefix, name);
+      } else {
+        error(compiler, "Class %s already defines a %smethod '%s'.",
             &compiler->enclosingClass->name->value, staticPrefix, name);
+      }
+
       break;
     }
   }
-  
   wrenIntBufferWrite(compiler->parser->vm, methods, symbol);
   return symbol;
 }


### PR DESCRIPTION
Resolves #1033.
Resolves #1036.

Better handling of very long error messages.