### PR TITLE
api: add wrenCopySlot

### DIFF
--- a/doc/site/embedding/slots-and-handles.markdown
+++ b/doc/site/embedding/slots-and-handles.markdown
@@ -97,6 +97,11 @@ length of the string using `strlen()`.
 
 [string]: ../values.html#strings
 
+If you need to move data from one slot to another, you can use `wrenCopySlot()`
+<pre class="snippet" data-lang="c">
+void wrenCopySlot(WrenVM* vm, int dstSlot, int srcSlot);
+</pre>
+
 ### Reading slots
 
 You can, of course, also pull data out of slots. Here are the simple ones:

--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -445,6 +445,9 @@ WREN_API const char* wrenGetSlotString(WrenVM* vm, int slot);
 // until the handle is released by calling [wrenReleaseHandle()].
 WREN_API WrenHandle* wrenGetSlotHandle(WrenVM* vm, int slot);
 
+// Copies the value from [srcSlot] to [dstSlot]
+WREN_API void wrenCopySlot(WrenVM* vm, int dstSlot, int srcSlot);
+
 // Stores the boolean [value] in [slot].
 WREN_API void wrenSetSlotBool(WrenVM* vm, int slot, bool value);
 

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1729,6 +1729,12 @@ static void setSlot(WrenVM* vm, int slot, Value value)
   vm->apiStack[slot] = value;
 }
 
+void wrenCopySlot(WrenVM* vm, int dst, int src)
+{
+  validateApiSlot(vm, src);
+  setSlot(vm, dst, vm->apiStack[src]);
+}
+
 void wrenSetSlotBool(WrenVM* vm, int slot, bool value)
 {
   setSlot(vm, slot, BOOL_VAL(value));


### PR DESCRIPTION
Simple utility function which copies a value from one slot to another, as originally proposed in #836