### PR TITLE
Introduce RawValue abstraction

### DIFF
--- a/projects/make.bsd/Makefile
+++ b/projects/make.bsd/Makefile
@@ -12,34 +12,31 @@ ifeq ($(config),release_64bit)
   wren_config = release_64bit
   wren_shared_config = release_64bit
   wren_test_config = release_64bit
-
-else ifeq ($(config),release_32bit)
+endif
+ifeq ($(config),release_32bit)
   wren_config = release_32bit
   wren_shared_config = release_32bit
   wren_test_config = release_32bit
-
-else ifeq ($(config),release_64bit-no-nan-tagging)
+endif
+ifeq ($(config),release_64bit-no-nan-tagging)
   wren_config = release_64bit-no-nan-tagging
   wren_shared_config = release_64bit-no-nan-tagging
   wren_test_config = release_64bit-no-nan-tagging
-
-else ifeq ($(config),debug_64bit)
+endif
+ifeq ($(config),debug_64bit)
   wren_config = debug_64bit
   wren_shared_config = debug_64bit
   wren_test_config = debug_64bit
-
-else ifeq ($(config),debug_32bit)
+endif
+ifeq ($(config),debug_32bit)
   wren_config = debug_32bit
   wren_shared_config = debug_32bit
   wren_test_config = debug_32bit
-
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+endif
+ifeq ($(config),debug_64bit-no-nan-tagging)
   wren_config = debug_64bit-no-nan-tagging
   wren_shared_config = debug_64bit-no-nan-tagging
   wren_test_config = debug_64bit-no-nan-tagging
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 PROJECTS := wren wren_shared wren_test
@@ -89,4 +86,4 @@ help:
 	@echo "   wren_shared"
 	@echo "   wren_test"
 	@echo ""
-	@echo "For more information, see https://github.com/premake/premake-core/wiki"
+	@echo "For more information, see http://industriousone.com/premake/quick-start"

--- a/projects/make.bsd/wren_shared.make
+++ b/projects/make.bsd/wren_shared.make
@@ -8,11 +8,14 @@ ifndef verbose
   SILENT = @
 endif
 
-.PHONY: clean prebuild
+.PHONY: clean prebuild prelink
 
-SHELLTYPE := posix
-ifeq (.exe,$(findstring .exe,$(ComSpec)))
-	SHELLTYPE := msdos
+SHELLTYPE := msdos
+ifeq (,$(ComSpec)$(COMSPEC))
+  SHELLTYPE := posix
+endif
+ifeq (/bin,$(findstring /bin,$(SHELL)))
+  SHELLTYPE := posix
 endif
 
 # Configurations
@@ -41,8 +44,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64 -shared -s
+endif
 
-else ifeq ($(config),release_32bit)
+ifeq ($(config),release_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.so
 OBJDIR = obj/32bit/Release/wren_shared
@@ -50,8 +54,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32 -shared -s
+endif
 
-else ifeq ($(config),release_64bit-no-nan-tagging)
+ifeq ($(config),release_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.so
 OBJDIR = obj/64bit-no-nan-tagging/Release/wren_shared
@@ -59,8 +64,9 @@ DEFINES += -DNDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -shared -s
+endif
 
-else ifeq ($(config),debug_64bit)
+ifeq ($(config),debug_64bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.so
 OBJDIR = obj/64bit/Debug/wren_shared
@@ -68,8 +74,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64 -shared
+endif
 
-else ifeq ($(config),debug_32bit)
+ifeq ($(config),debug_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.so
 OBJDIR = obj/32bit/Debug/wren_shared
@@ -77,8 +84,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32 -shared
+endif
 
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+ifeq ($(config),debug_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.so
 OBJDIR = obj/64bit-no-nan-tagging/Debug/wren_shared
@@ -86,9 +94,6 @@ DEFINES += -DDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -shared
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -113,11 +118,10 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 # Rules
 # #############################################
 
-all: $(TARGET)
+all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
-	$(PRELINKCMDS)
+$(TARGET): $(GCH) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	@echo Linking wren_shared
 	$(SILENT) $(LINKCMD)
 	$(POSTBUILDCMDS)
@@ -148,22 +152,21 @@ else
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
-prebuild: | $(OBJDIR)
+prebuild:
 	$(PREBUILDCMDS)
 
+prelink:
+	$(PRELINKCMDS)
+
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | prebuild
+$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
-ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
 else
-	$(SILENT) echo $null >> "$@"
-endif
-else
-$(OBJECTS): | prebuild
+$(OBJECTS): | $(OBJDIR)
 endif
 
 
@@ -200,5 +203,5 @@ $(OBJDIR)/wren_vm.o: ../../src/vm/wren_vm.c
 
 -include $(OBJECTS:%.o=%.d)
 ifneq (,$(PCH))
-  -include $(PCH_PLACEHOLDER).d
+  -include "$(PCH_PLACEHOLDER).d"
 endif

--- a/projects/make.bsd/wren_test.make
+++ b/projects/make.bsd/wren_test.make
@@ -8,11 +8,14 @@ ifndef verbose
   SILENT = @
 endif
 
-.PHONY: clean prebuild
+.PHONY: clean prebuild prelink
 
-SHELLTYPE := posix
-ifeq (.exe,$(findstring .exe,$(ComSpec)))
-	SHELLTYPE := msdos
+SHELLTYPE := msdos
+ifeq (,$(ComSpec)$(COMSPEC))
+  SHELLTYPE := posix
+endif
+ifeq (/bin,$(findstring /bin,$(SHELL)))
+  SHELLTYPE := posix
 endif
 
 # Configurations
@@ -41,8 +44,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -O2
 LIBS += ../../lib/libwren.a -lm
 LDDEPS += ../../lib/libwren.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64 -s
+endif
 
-else ifeq ($(config),release_32bit)
+ifeq ($(config),release_32bit)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test
 OBJDIR = obj/32bit/Release/wren_test
@@ -52,8 +56,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -O2
 LIBS += ../../lib/libwren.a -lm
 LDDEPS += ../../lib/libwren.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32 -s
+endif
 
-else ifeq ($(config),release_64bit-no-nan-tagging)
+ifeq ($(config),release_64bit-no-nan-tagging)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test
 OBJDIR = obj/64bit-no-nan-tagging/Release/wren_test
@@ -63,8 +68,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O2
 LIBS += ../../lib/libwren.a -lm
 LDDEPS += ../../lib/libwren.a
 ALL_LDFLAGS += $(LDFLAGS) -s
+endif
 
-else ifeq ($(config),debug_64bit)
+ifeq ($(config),debug_64bit)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test_d
 OBJDIR = obj/64bit/Debug/wren_test
@@ -74,8 +80,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -g
 LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64
+endif
 
-else ifeq ($(config),debug_32bit)
+ifeq ($(config),debug_32bit)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test_d
 OBJDIR = obj/32bit/Debug/wren_test
@@ -85,8 +92,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -g
 LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32
+endif
 
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+ifeq ($(config),debug_64bit-no-nan-tagging)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test_d
 OBJDIR = obj/64bit-no-nan-tagging/Debug/wren_test
@@ -96,9 +104,6 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS)
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -123,6 +128,7 @@ OBJECTS += $(OBJDIR)/lists.o
 OBJECTS += $(OBJDIR)/main.o
 OBJECTS += $(OBJDIR)/maps.o
 OBJECTS += $(OBJDIR)/new_vm.o
+OBJECTS += $(OBJDIR)/raw_value.o
 OBJECTS += $(OBJDIR)/reset_stack_after_call_abort.o
 OBJECTS += $(OBJDIR)/reset_stack_after_foreign_construct.o
 OBJECTS += $(OBJDIR)/resolution.o
@@ -133,11 +139,10 @@ OBJECTS += $(OBJDIR)/user_data.o
 # Rules
 # #############################################
 
-all: $(TARGET)
+all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
-	$(PRELINKCMDS)
+$(TARGET): $(GCH) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	@echo Linking wren_test
 	$(SILENT) $(LINKCMD)
 	$(POSTBUILDCMDS)
@@ -168,22 +173,21 @@ else
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
-prebuild: | $(OBJDIR)
+prebuild:
 	$(PREBUILDCMDS)
 
+prelink:
+	$(PRELINKCMDS)
+
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | prebuild
+$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
-ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
 else
-	$(SILENT) echo $null >> "$@"
-endif
-else
-$(OBJECTS): | prebuild
+$(OBJECTS): | $(OBJDIR)
 endif
 
 
@@ -226,6 +230,9 @@ $(OBJDIR)/maps.o: ../../test/api/maps.c
 $(OBJDIR)/new_vm.o: ../../test/api/new_vm.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/raw_value.o: ../../test/api/raw_value.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/reset_stack_after_call_abort.o: ../../test/api/reset_stack_after_call_abort.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
@@ -250,5 +257,5 @@ $(OBJDIR)/test.o: ../../test/test.c
 
 -include $(OBJECTS:%.o=%.d)
 ifneq (,$(PCH))
-  -include $(PCH_PLACEHOLDER).d
+  -include "$(PCH_PLACEHOLDER).d"
 endif

--- a/projects/make.mac/Makefile
+++ b/projects/make.mac/Makefile
@@ -12,34 +12,31 @@ ifeq ($(config),release_64bit)
   wren_config = release_64bit
   wren_shared_config = release_64bit
   wren_test_config = release_64bit
-
-else ifeq ($(config),release_32bit)
+endif
+ifeq ($(config),release_32bit)
   wren_config = release_32bit
   wren_shared_config = release_32bit
   wren_test_config = release_32bit
-
-else ifeq ($(config),release_64bit-no-nan-tagging)
+endif
+ifeq ($(config),release_64bit-no-nan-tagging)
   wren_config = release_64bit-no-nan-tagging
   wren_shared_config = release_64bit-no-nan-tagging
   wren_test_config = release_64bit-no-nan-tagging
-
-else ifeq ($(config),debug_64bit)
+endif
+ifeq ($(config),debug_64bit)
   wren_config = debug_64bit
   wren_shared_config = debug_64bit
   wren_test_config = debug_64bit
-
-else ifeq ($(config),debug_32bit)
+endif
+ifeq ($(config),debug_32bit)
   wren_config = debug_32bit
   wren_shared_config = debug_32bit
   wren_test_config = debug_32bit
-
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+endif
+ifeq ($(config),debug_64bit-no-nan-tagging)
   wren_config = debug_64bit-no-nan-tagging
   wren_shared_config = debug_64bit-no-nan-tagging
   wren_test_config = debug_64bit-no-nan-tagging
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 PROJECTS := wren wren_shared wren_test
@@ -89,4 +86,4 @@ help:
 	@echo "   wren_shared"
 	@echo "   wren_test"
 	@echo ""
-	@echo "For more information, see https://github.com/premake/premake-core/wiki"
+	@echo "For more information, see http://industriousone.com/premake/quick-start"

--- a/projects/make.mac/wren.make
+++ b/projects/make.mac/wren.make
@@ -8,11 +8,14 @@ ifndef verbose
   SILENT = @
 endif
 
-.PHONY: clean prebuild
+.PHONY: clean prebuild prelink
 
-SHELLTYPE := posix
-ifeq (.exe,$(findstring .exe,$(ComSpec)))
-	SHELLTYPE := msdos
+SHELLTYPE := msdos
+ifeq (,$(ComSpec)$(COMSPEC))
+  SHELLTYPE := posix
+endif
+ifeq (/bin,$(findstring /bin,$(SHELL)))
+  SHELLTYPE := posix
 endif
 
 # Configurations
@@ -49,8 +52,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -O2
 ALL_LDFLAGS += $(LDFLAGS) -m64
+endif
 
-else ifeq ($(config),release_32bit)
+ifeq ($(config),release_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.a
 OBJDIR = obj/32bit/Release/wren
@@ -58,8 +62,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -O2
 ALL_LDFLAGS += $(LDFLAGS) -m32
+endif
 
-else ifeq ($(config),release_64bit-no-nan-tagging)
+ifeq ($(config),release_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.a
 OBJDIR = obj/64bit-no-nan-tagging/Release/wren
@@ -67,8 +72,9 @@ DEFINES += -DNDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -O2 -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O2
 ALL_LDFLAGS += $(LDFLAGS)
+endif
 
-else ifeq ($(config),debug_64bit)
+ifeq ($(config),debug_64bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.a
 OBJDIR = obj/64bit/Debug/wren
@@ -76,8 +82,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -g
 ALL_LDFLAGS += $(LDFLAGS) -m64
+endif
 
-else ifeq ($(config),debug_32bit)
+ifeq ($(config),debug_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.a
 OBJDIR = obj/32bit/Debug/wren
@@ -85,8 +92,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -g
 ALL_LDFLAGS += $(LDFLAGS) -m32
+endif
 
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+ifeq ($(config),debug_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.a
 OBJDIR = obj/64bit-no-nan-tagging/Debug/wren
@@ -94,9 +102,6 @@ DEFINES += -DDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -121,11 +126,10 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 # Rules
 # #############################################
 
-all: $(TARGET)
+all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
-	$(PRELINKCMDS)
+$(TARGET): $(GCH) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	@echo Linking wren
 	$(SILENT) $(LINKCMD)
 	$(POSTBUILDCMDS)
@@ -156,22 +160,21 @@ else
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
-prebuild: | $(OBJDIR)
+prebuild:
 	$(PREBUILDCMDS)
 
+prelink:
+	$(PRELINKCMDS)
+
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | prebuild
+$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
-ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
 else
-	$(SILENT) echo $null >> "$@"
-endif
-else
-$(OBJECTS): | prebuild
+$(OBJECTS): | $(OBJDIR)
 endif
 
 
@@ -208,5 +211,5 @@ $(OBJDIR)/wren_vm.o: ../../src/vm/wren_vm.c
 
 -include $(OBJECTS:%.o=%.d)
 ifneq (,$(PCH))
-  -include $(PCH_PLACEHOLDER).d
+  -include "$(PCH_PLACEHOLDER).d"
 endif

--- a/projects/make.mac/wren_shared.make
+++ b/projects/make.mac/wren_shared.make
@@ -8,11 +8,14 @@ ifndef verbose
   SILENT = @
 endif
 
-.PHONY: clean prebuild
+.PHONY: clean prebuild prelink
 
-SHELLTYPE := posix
-ifeq (.exe,$(findstring .exe,$(ComSpec)))
-	SHELLTYPE := msdos
+SHELLTYPE := msdos
+ifeq (,$(ComSpec)$(COMSPEC))
+  SHELLTYPE := posix
+endif
+ifeq (/bin,$(findstring /bin,$(SHELL)))
+  SHELLTYPE := posix
 endif
 
 # Configurations
@@ -49,8 +52,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -m64 -dynamiclib -Wl,-install_name,@rpath/libwren.dylib
+endif
 
-else ifeq ($(config),release_32bit)
+ifeq ($(config),release_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.dylib
 OBJDIR = obj/32bit/Release/wren_shared
@@ -58,8 +62,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -m32 -dynamiclib -Wl,-install_name,@rpath/libwren.dylib
+endif
 
-else ifeq ($(config),release_64bit-no-nan-tagging)
+ifeq ($(config),release_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.dylib
 OBJDIR = obj/64bit-no-nan-tagging/Release/wren_shared
@@ -67,8 +72,9 @@ DEFINES += -DNDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -dynamiclib -Wl,-install_name,@rpath/libwren.dylib
+endif
 
-else ifeq ($(config),debug_64bit)
+ifeq ($(config),debug_64bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.dylib
 OBJDIR = obj/64bit/Debug/wren_shared
@@ -76,8 +82,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -m64 -dynamiclib -Wl,-install_name,@rpath/libwren_d.dylib
+endif
 
-else ifeq ($(config),debug_32bit)
+ifeq ($(config),debug_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.dylib
 OBJDIR = obj/32bit/Debug/wren_shared
@@ -85,8 +92,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -m32 -dynamiclib -Wl,-install_name,@rpath/libwren_d.dylib
+endif
 
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+ifeq ($(config),debug_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.dylib
 OBJDIR = obj/64bit-no-nan-tagging/Debug/wren_shared
@@ -94,9 +102,6 @@ DEFINES += -DDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -dynamiclib -Wl,-install_name,@rpath/libwren_d.dylib
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -121,11 +126,10 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 # Rules
 # #############################################
 
-all: $(TARGET)
+all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
-	$(PRELINKCMDS)
+$(TARGET): $(GCH) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	@echo Linking wren_shared
 	$(SILENT) $(LINKCMD)
 	$(POSTBUILDCMDS)
@@ -156,22 +160,21 @@ else
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
-prebuild: | $(OBJDIR)
+prebuild:
 	$(PREBUILDCMDS)
 
+prelink:
+	$(PRELINKCMDS)
+
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | prebuild
+$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
-ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
 else
-	$(SILENT) echo $null >> "$@"
-endif
-else
-$(OBJECTS): | prebuild
+$(OBJECTS): | $(OBJDIR)
 endif
 
 
@@ -208,5 +211,5 @@ $(OBJDIR)/wren_vm.o: ../../src/vm/wren_vm.c
 
 -include $(OBJECTS:%.o=%.d)
 ifneq (,$(PCH))
-  -include $(PCH_PLACEHOLDER).d
+  -include "$(PCH_PLACEHOLDER).d"
 endif

--- a/projects/make/Makefile
+++ b/projects/make/Makefile
@@ -12,34 +12,31 @@ ifeq ($(config),release_64bit)
   wren_config = release_64bit
   wren_shared_config = release_64bit
   wren_test_config = release_64bit
-
-else ifeq ($(config),release_32bit)
+endif
+ifeq ($(config),release_32bit)
   wren_config = release_32bit
   wren_shared_config = release_32bit
   wren_test_config = release_32bit
-
-else ifeq ($(config),release_64bit-no-nan-tagging)
+endif
+ifeq ($(config),release_64bit-no-nan-tagging)
   wren_config = release_64bit-no-nan-tagging
   wren_shared_config = release_64bit-no-nan-tagging
   wren_test_config = release_64bit-no-nan-tagging
-
-else ifeq ($(config),debug_64bit)
+endif
+ifeq ($(config),debug_64bit)
   wren_config = debug_64bit
   wren_shared_config = debug_64bit
   wren_test_config = debug_64bit
-
-else ifeq ($(config),debug_32bit)
+endif
+ifeq ($(config),debug_32bit)
   wren_config = debug_32bit
   wren_shared_config = debug_32bit
   wren_test_config = debug_32bit
-
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+endif
+ifeq ($(config),debug_64bit-no-nan-tagging)
   wren_config = debug_64bit-no-nan-tagging
   wren_shared_config = debug_64bit-no-nan-tagging
   wren_test_config = debug_64bit-no-nan-tagging
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 PROJECTS := wren wren_shared wren_test
@@ -89,4 +86,4 @@ help:
 	@echo "   wren_shared"
 	@echo "   wren_test"
 	@echo ""
-	@echo "For more information, see https://github.com/premake/premake-core/wiki"
+	@echo "For more information, see http://industriousone.com/premake/quick-start"

--- a/projects/make/wren_shared.make
+++ b/projects/make/wren_shared.make
@@ -8,11 +8,14 @@ ifndef verbose
   SILENT = @
 endif
 
-.PHONY: clean prebuild
+.PHONY: clean prebuild prelink
 
-SHELLTYPE := posix
-ifeq (.exe,$(findstring .exe,$(ComSpec)))
-	SHELLTYPE := msdos
+SHELLTYPE := msdos
+ifeq (,$(ComSpec)$(COMSPEC))
+  SHELLTYPE := posix
+endif
+ifeq (/bin,$(findstring /bin,$(SHELL)))
+  SHELLTYPE := posix
 endif
 
 # Configurations
@@ -41,8 +44,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64 -shared -Wl,-soname=libwren.so -s
+endif
 
-else ifeq ($(config),release_32bit)
+ifeq ($(config),release_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.so
 OBJDIR = obj/32bit/Release/wren_shared
@@ -50,8 +54,9 @@ DEFINES += -DNDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32 -shared -Wl,-soname=libwren.so -s
+endif
 
-else ifeq ($(config),release_64bit-no-nan-tagging)
+ifeq ($(config),release_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren.so
 OBJDIR = obj/64bit-no-nan-tagging/Release/wren_shared
@@ -59,8 +64,9 @@ DEFINES += -DNDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -O2 -fPIC -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O2 -fPIC
 ALL_LDFLAGS += $(LDFLAGS) -shared -Wl,-soname=libwren.so -s
+endif
 
-else ifeq ($(config),debug_64bit)
+ifeq ($(config),debug_64bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.so
 OBJDIR = obj/64bit/Debug/wren_shared
@@ -68,8 +74,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m64 -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64 -shared -Wl,-soname=libwren_d.so
+endif
 
-else ifeq ($(config),debug_32bit)
+ifeq ($(config),debug_32bit)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.so
 OBJDIR = obj/32bit/Debug/wren_shared
@@ -77,8 +84,9 @@ DEFINES += -DDEBUG
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -m32 -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32 -shared -Wl,-soname=libwren_d.so
+endif
 
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+ifeq ($(config),debug_64bit-no-nan-tagging)
 TARGETDIR = ../../lib
 TARGET = $(TARGETDIR)/libwren_d.so
 OBJDIR = obj/64bit-no-nan-tagging/Debug/wren_shared
@@ -86,9 +94,6 @@ DEFINES += -DDEBUG -DWREN_NAN_TAGGING=0
 ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -fPIC -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -fPIC -g
 ALL_LDFLAGS += $(LDFLAGS) -shared -Wl,-soname=libwren_d.so
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -113,11 +118,10 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 # Rules
 # #############################################
 
-all: $(TARGET)
+all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
-	$(PRELINKCMDS)
+$(TARGET): $(GCH) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	@echo Linking wren_shared
 	$(SILENT) $(LINKCMD)
 	$(POSTBUILDCMDS)
@@ -148,22 +152,21 @@ else
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
-prebuild: | $(OBJDIR)
+prebuild:
 	$(PREBUILDCMDS)
 
+prelink:
+	$(PRELINKCMDS)
+
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | prebuild
+$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
-ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
 else
-	$(SILENT) echo $null >> "$@"
-endif
-else
-$(OBJECTS): | prebuild
+$(OBJECTS): | $(OBJDIR)
 endif
 
 
@@ -200,5 +203,5 @@ $(OBJDIR)/wren_vm.o: ../../src/vm/wren_vm.c
 
 -include $(OBJECTS:%.o=%.d)
 ifneq (,$(PCH))
-  -include $(PCH_PLACEHOLDER).d
+  -include "$(PCH_PLACEHOLDER).d"
 endif

--- a/projects/make/wren_test.make
+++ b/projects/make/wren_test.make
@@ -8,11 +8,14 @@ ifndef verbose
   SILENT = @
 endif
 
-.PHONY: clean prebuild
+.PHONY: clean prebuild prelink
 
-SHELLTYPE := posix
-ifeq (.exe,$(findstring .exe,$(ComSpec)))
-	SHELLTYPE := msdos
+SHELLTYPE := msdos
+ifeq (,$(ComSpec)$(COMSPEC))
+  SHELLTYPE := posix
+endif
+ifeq (/bin,$(findstring /bin,$(SHELL)))
+  SHELLTYPE := posix
 endif
 
 # Configurations
@@ -41,8 +44,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -O2
 LIBS += ../../lib/libwren.a -lm
 LDDEPS += ../../lib/libwren.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64 -s
+endif
 
-else ifeq ($(config),release_32bit)
+ifeq ($(config),release_32bit)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test
 OBJDIR = obj/32bit/Release/wren_test
@@ -52,8 +56,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -O2
 LIBS += ../../lib/libwren.a -lm
 LDDEPS += ../../lib/libwren.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32 -s
+endif
 
-else ifeq ($(config),release_64bit-no-nan-tagging)
+ifeq ($(config),release_64bit-no-nan-tagging)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test
 OBJDIR = obj/64bit-no-nan-tagging/Release/wren_test
@@ -63,8 +68,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -O2
 LIBS += ../../lib/libwren.a -lm
 LDDEPS += ../../lib/libwren.a
 ALL_LDFLAGS += $(LDFLAGS) -s
+endif
 
-else ifeq ($(config),debug_64bit)
+ifeq ($(config),debug_64bit)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test_d
 OBJDIR = obj/64bit/Debug/wren_test
@@ -74,8 +80,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m64 -g
 LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib64 -m64
+endif
 
-else ifeq ($(config),debug_32bit)
+ifeq ($(config),debug_32bit)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test_d
 OBJDIR = obj/32bit/Debug/wren_test
@@ -85,8 +92,9 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -m32 -g
 LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS) -L/usr/lib32 -m32
+endif
 
-else ifeq ($(config),debug_64bit-no-nan-tagging)
+ifeq ($(config),debug_64bit-no-nan-tagging)
 TARGETDIR = ../../bin
 TARGET = $(TARGETDIR)/wren_test_d
 OBJDIR = obj/64bit-no-nan-tagging/Debug/wren_test
@@ -96,9 +104,6 @@ ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 LIBS += ../../lib/libwren_d.a -lm
 LDDEPS += ../../lib/libwren_d.a
 ALL_LDFLAGS += $(LDFLAGS)
-
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -123,6 +128,7 @@ OBJECTS += $(OBJDIR)/lists.o
 OBJECTS += $(OBJDIR)/main.o
 OBJECTS += $(OBJDIR)/maps.o
 OBJECTS += $(OBJDIR)/new_vm.o
+OBJECTS += $(OBJDIR)/raw_value.o
 OBJECTS += $(OBJDIR)/reset_stack_after_call_abort.o
 OBJECTS += $(OBJDIR)/reset_stack_after_foreign_construct.o
 OBJECTS += $(OBJDIR)/resolution.o
@@ -133,11 +139,10 @@ OBJECTS += $(OBJDIR)/user_data.o
 # Rules
 # #############################################
 
-all: $(TARGET)
+all: prebuild prelink $(TARGET) | $(TARGETDIR) $(OBJDIR)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
-	$(PRELINKCMDS)
+$(TARGET): $(GCH) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	@echo Linking wren_test
 	$(SILENT) $(LINKCMD)
 	$(POSTBUILDCMDS)
@@ -168,22 +173,21 @@ else
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 
-prebuild: | $(OBJDIR)
+prebuild:
 	$(PREBUILDCMDS)
 
+prelink:
+	$(PRELINKCMDS)
+
 ifneq (,$(PCH))
-$(OBJECTS): $(GCH) | $(PCH_PLACEHOLDER)
-$(GCH): $(PCH) | prebuild
+$(OBJECTS): $(GCH) $(PCH) | $(OBJDIR) $(PCH_PLACEHOLDER)
+$(GCH): $(PCH) | $(OBJDIR)
 	@echo $(notdir $<)
 	$(SILENT) $(CC) -x c-header $(ALL_CFLAGS) -o "$@" -MF "$(@:%.gch=%.d)" -c "$<"
 $(PCH_PLACEHOLDER): $(GCH) | $(OBJDIR)
-ifeq (posix,$(SHELLTYPE))
 	$(SILENT) touch "$@"
 else
-	$(SILENT) echo $null >> "$@"
-endif
-else
-$(OBJECTS): | prebuild
+$(OBJECTS): | $(OBJDIR)
 endif
 
 
@@ -226,6 +230,9 @@ $(OBJDIR)/maps.o: ../../test/api/maps.c
 $(OBJDIR)/new_vm.o: ../../test/api/new_vm.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
+$(OBJDIR)/raw_value.o: ../../test/api/raw_value.c
+	@echo $(notdir $<)
+	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
 $(OBJDIR)/reset_stack_after_call_abort.o: ../../test/api/reset_stack_after_call_abort.c
 	@echo $(notdir $<)
 	$(SILENT) $(CC) $(ALL_CFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
@@ -250,5 +257,5 @@ $(OBJDIR)/test.o: ../../test/test.c
 
 -include $(OBJECTS:%.o=%.d)
 ifneq (,$(PCH))
-  -include $(PCH_PLACEHOLDER).d
+  -include "$(PCH_PLACEHOLDER).d"
 endif

--- a/projects/vs2017/wren.vcxproj
+++ b/projects/vs2017/wren.vcxproj
@@ -55,7 +55,7 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>latest</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">
@@ -256,6 +256,7 @@
     <ClInclude Include="..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\src\vm\wren_debug.h" />
+    <ClInclude Include="..\..\src\vm\wren_math.h" />
     <ClInclude Include="..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\src\vm\wren_utils.h" />

--- a/projects/vs2017/wren.vcxproj.filters
+++ b/projects/vs2017/wren.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="..\..\src\vm\wren_debug.h">
       <Filter>vm</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\vm\wren_math.h">
+      <Filter>vm</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\vm\wren_opcodes.h">
       <Filter>vm</Filter>
     </ClInclude>

--- a/projects/vs2017/wren_shared.vcxproj
+++ b/projects/vs2017/wren_shared.vcxproj
@@ -55,7 +55,7 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren_shared</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>latest</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">
@@ -268,6 +268,7 @@
     <ClInclude Include="..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\src\vm\wren_debug.h" />
+    <ClInclude Include="..\..\src\vm\wren_math.h" />
     <ClInclude Include="..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\src\vm\wren_utils.h" />

--- a/projects/vs2017/wren_shared.vcxproj.filters
+++ b/projects/vs2017/wren_shared.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="..\..\src\vm\wren_debug.h">
       <Filter>vm</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\vm\wren_math.h">
+      <Filter>vm</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\vm\wren_opcodes.h">
       <Filter>vm</Filter>
     </ClInclude>

--- a/projects/vs2017/wren_test.vcxproj
+++ b/projects/vs2017/wren_test.vcxproj
@@ -55,7 +55,7 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren_test</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>latest</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">
@@ -267,6 +267,7 @@
     <ClInclude Include="..\..\test\api\lists.h" />
     <ClInclude Include="..\..\test\api\maps.h" />
     <ClInclude Include="..\..\test\api\new_vm.h" />
+    <ClInclude Include="..\..\test\api\raw_value.h" />
     <ClInclude Include="..\..\test\api\reset_stack_after_call_abort.h" />
     <ClInclude Include="..\..\test\api\reset_stack_after_foreign_construct.h" />
     <ClInclude Include="..\..\test\api\resolution.h" />
@@ -287,6 +288,7 @@
     <ClCompile Include="..\..\test\api\lists.c" />
     <ClCompile Include="..\..\test\api\maps.c" />
     <ClCompile Include="..\..\test\api\new_vm.c" />
+    <ClCompile Include="..\..\test\api\raw_value.c" />
     <ClCompile Include="..\..\test\api\reset_stack_after_call_abort.c" />
     <ClCompile Include="..\..\test\api\reset_stack_after_foreign_construct.c" />
     <ClCompile Include="..\..\test\api\resolution.c" />

--- a/projects/vs2017/wren_test.vcxproj.filters
+++ b/projects/vs2017/wren_test.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="..\..\test\api\new_vm.h">
       <Filter>api</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\test\api\raw_value.h">
+      <Filter>api</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\test\api\reset_stack_after_call_abort.h">
       <Filter>api</Filter>
     </ClInclude>
@@ -94,6 +97,9 @@
       <Filter>api</Filter>
     </ClCompile>
     <ClCompile Include="..\..\test\api\new_vm.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\test\api\raw_value.c">
       <Filter>api</Filter>
     </ClCompile>
     <ClCompile Include="..\..\test\api\reset_stack_after_call_abort.c">

--- a/projects/xcode/wren.xcodeproj/project.pbxproj
+++ b/projects/xcode/wren.xcodeproj/project.pbxproj
@@ -7,44 +7,45 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		032ED59302D1B8C53D266BD3 /* wren_opt_random.c in Sources */ = {isa = PBXBuildFile; fileRef = 737815DBCADD88CD7CEBA41B /* wren_opt_random.c */; };
-		20773D38B5EDFC6A248A5378 /* wren_debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 39C26800695436F244617640 /* wren_debug.c */; };
-		76585F8088823C32BC7325C0 /* wren_compiler.c in Sources */ = {isa = PBXBuildFile; fileRef = C5FFB2C8BFC16F3AF9C07108 /* wren_compiler.c */; };
-		76CC0A9CBADFDBCEAEB160DC /* wren_primitive.c in Sources */ = {isa = PBXBuildFile; fileRef = 6F616124E0840216964AAF64 /* wren_primitive.c */; };
-		7FA807D04313C98281B76E10 /* wren_vm.c in Sources */ = {isa = PBXBuildFile; fileRef = B65A1C18AFC01D8AA35B7A58 /* wren_vm.c */; };
-		8D5FBD0C22D67C3E9172D34C /* wren_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A5CED894D560A786B06DE6D4 /* wren_utils.c */; };
-		B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */ = {isa = PBXBuildFile; fileRef = A24154A4F8CEBF16D147D2E4 /* wren_core.c */; };
-		D1029E9FB01FB8D18C2914DF /* wren_opt_meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 62592227F4E6EC195DBF9067 /* wren_opt_meta.c */; };
-		E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */ = {isa = PBXBuildFile; fileRef = AD30296CDCC1F85EB7CF37AC /* wren_value.c */; };
+		51FC59E1DB0F64E3761F627751CE966537590FE5EE25A4 /* wren_value.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E0EE55AD30296CEB72CA8CDCC1F85E348877F6B7CF37AC /* wren_value.c */; };
+		6C4ADE87FA807D089774CD54313C9821583E5BC81B76E10 /* wren_vm.c in Sources */ = {isa = PBXBuildFile; fileRef = 6C0D5F84B65A1C1845539D81AFC01D8AD199DCD6A35B7A58 /* wren_vm.c */; };
+		6FD1F8C0032ED593B68B31602D1B8C5A6A130ED3D266BD3 /* wren_opt_random.c in Sources */ = {isa = PBXBuildFile; fileRef = CA644125737815DB6A4E4BA1CADD88CDE365E21A7CEBA41B /* wren_opt_random.c */; };
+		8E2BFBF320773D3871501EFBB5EDFC6AF31158A9248A5378 /* wren_debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 978A996E39C268007F1C75A5695436F2C832230F44617640 /* wren_debug.c */; };
+		9601678D76CC0A9C332CC194BADFDBCECF372723AEB160DC /* wren_primitive.c in Sources */ = {isa = PBXBuildFile; fileRef = D44ABAC26F6161248D99667CE08402162CAEC553964AAF64 /* wren_primitive.c */; };
+		9A07EECA8D5FBD0C7D2C11D322D67C3EFEED4B809172D34C /* wren_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = ACDD9FB0A5CED894946F7BE7D560A786DD852951B06DE6D4 /* wren_utils.c */; };
+		A6EE846CD1029E9F3EBA59DCB01FB8D1FD8A127C8C2914DF /* wren_opt_meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 37890E6B62592227B630668F4E6EC19E124B99D5DBF9067 /* wren_opt_meta.c */; };
+		D8C7769676585F8051FD19D088823C323E62AA02BC7325C0 /* wren_compiler.c in Sources */ = {isa = PBXBuildFile; fileRef = 9BCFC5AC5FFB2C83E54AEEFBFC16F3A32B914CFF9C07108 /* wren_compiler.c */; };
+		FA6E4000B9CCD11CC1FC4534EBC61BCE42ED671C65A5575C /* wren_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 435137FAA24154A4B14FB501F8CEBF166A9EB693D147D2E4 /* wren_core.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		14FE11AE703F65204399AFEE /* wren_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_common.h; path = ../../src/vm/wren_common.h; sourceTree = "<group>"; };
-		27B7A19221795E045B785FD2 /* wren_compiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_compiler.h; path = ../../src/vm/wren_compiler.h; sourceTree = "<group>"; };
-		39C26800695436F244617640 /* wren_debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_debug.c; path = ../../src/vm/wren_debug.c; sourceTree = "<group>"; };
-		44AC34EA743E03DC4F4B432A /* wren_debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_debug.h; path = ../../src/vm/wren_debug.h; sourceTree = "<group>"; };
-		49DA870B4D4B593DCEB7FD4B /* libwren.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libwren.a; path = libwren.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4BF57B22455B7C9438F6D962 /* wren_vm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_vm.h; path = ../../src/vm/wren_vm.h; sourceTree = "<group>"; };
-		62592227F4E6EC195DBF9067 /* wren_opt_meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_meta.c; path = ../../src/optional/wren_opt_meta.c; sourceTree = "<group>"; };
-		6F616124E0840216964AAF64 /* wren_primitive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_primitive.c; path = ../../src/vm/wren_primitive.c; sourceTree = "<group>"; };
-		737815DBCADD88CD7CEBA41B /* wren_opt_random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_random.c; path = ../../src/optional/wren_opt_random.c; sourceTree = "<group>"; };
-		7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opcodes.h; path = ../../src/vm/wren_opcodes.h; sourceTree = "<group>"; };
-		8BA7E8EEE2355360BAAE672E /* wren_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_core.h; path = ../../src/vm/wren_core.h; sourceTree = "<group>"; };
-		A24154A4F8CEBF16D147D2E4 /* wren_core.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_core.c; path = ../../src/vm/wren_core.c; sourceTree = "<group>"; };
-		A5CED894D560A786B06DE6D4 /* wren_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_utils.c; path = ../../src/vm/wren_utils.c; sourceTree = "<group>"; };
-		AAEE79A50253EC97B46207E5 /* wren_opt_random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_random.h; path = ../../src/optional/wren_opt_random.h; sourceTree = "<group>"; };
-		AD30296CDCC1F85EB7CF37AC /* wren_value.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_value.c; path = ../../src/vm/wren_value.c; sourceTree = "<group>"; };
-		B0B8A57EE04A7470BB57B3BE /* wren_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_utils.h; path = ../../src/vm/wren_utils.h; sourceTree = "<group>"; };
-		B65A1C18AFC01D8AA35B7A58 /* wren_vm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_vm.c; path = ../../src/vm/wren_vm.c; sourceTree = "<group>"; };
-		B819F656E7ABC548C2B90496 /* wren_value.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_value.h; path = ../../src/vm/wren_value.h; sourceTree = "<group>"; };
-		B8CA70B14B583AA3B430DEF1 /* wren_opt_meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_meta.h; path = ../../src/optional/wren_opt_meta.h; sourceTree = "<group>"; };
-		C5FFB2C8BFC16F3AF9C07108 /* wren_compiler.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_compiler.c; path = ../../src/vm/wren_compiler.c; sourceTree = "<group>"; };
-		ECE6D43F03F96F71F4156A7F /* wren.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren.h; path = ../../src/include/wren.h; sourceTree = "<group>"; };
-		FCC7D88E6DEA798023B126CE /* wren_primitive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_primitive.h; path = ../../src/vm/wren_primitive.h; sourceTree = "<group>"; };
+		3084E635FCC7D88EE9D391F06DEA798088E8F0C723B126CE /* wren_primitive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_primitive.h; path = ../../src/vm/wren_primitive.h; sourceTree = "<group>"; };
+		31A71877BB4B776DC20EE0CAC98AF68E9C0A3DBBFB0E5B6 /* wren_opcodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opcodes.h; path = ../../src/vm/wren_opcodes.h; sourceTree = "<group>"; };
+		37890E6B62592227B630668F4E6EC19E124B99D5DBF9067 /* wren_opt_meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_meta.c; path = ../../src/optional/wren_opt_meta.c; sourceTree = "<group>"; };
+		3E0EE55AD30296CEB72CA8CDCC1F85E348877F6B7CF37AC /* wren_value.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_value.c; path = ../../src/vm/wren_value.c; sourceTree = "<group>"; };
+		435137FAA24154A4B14FB501F8CEBF166A9EB693D147D2E4 /* wren_core.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_core.c; path = ../../src/vm/wren_core.c; sourceTree = "<group>"; };
+		4DBFC1DA8BA7E8EEBBBE3EE1E2355360750D4073BAAE672E /* wren_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_core.h; path = ../../src/vm/wren_core.h; sourceTree = "<group>"; };
+		4DF8C9AA4BF57B22273F07A7455B7C94B38546FC38F6D962 /* wren_vm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_vm.h; path = ../../src/vm/wren_vm.h; sourceTree = "<group>"; };
+		51D658DB0B8A57EECAF41C4E04A747035C4EF2EBB57B3BE /* wren_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_utils.h; path = ../../src/vm/wren_utils.h; sourceTree = "<group>"; };
+		5A1BD6E227B7A1928EB3897721795E048317EF575B785FD2 /* wren_compiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_compiler.h; path = ../../src/vm/wren_compiler.h; sourceTree = "<group>"; };
+		5C20B432B819F65643B29069E7ABC5488CC83DD3C2B90496 /* wren_value.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_value.h; path = ../../src/vm/wren_value.h; sourceTree = "<group>"; };
+		6C0D5F84B65A1C1845539D81AFC01D8AD199DCD6A35B7A58 /* wren_vm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_vm.c; path = ../../src/vm/wren_vm.c; sourceTree = "<group>"; };
+		8949E3BDAAEE79A52933EE3A0253EC97A24B84B2B46207E5 /* wren_opt_random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_random.h; path = ../../src/optional/wren_opt_random.h; sourceTree = "<group>"; };
+		962ECC2714FE11AEA9A892E8703F65208EDF42354399AFEE /* wren_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_common.h; path = ../../src/vm/wren_common.h; sourceTree = "<group>"; };
+		978A996E39C268007F1C75A5695436F2C832230F44617640 /* wren_debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_debug.c; path = ../../src/vm/wren_debug.c; sourceTree = "<group>"; };
+		9BCFC5AC5FFB2C83E54AEEFBFC16F3A32B914CFF9C07108 /* wren_compiler.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_compiler.c; path = ../../src/vm/wren_compiler.c; sourceTree = "<group>"; };
+		A3605D15B8CA70B1773A55134B583AA34CFC0847B430DEF1 /* wren_opt_meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_meta.h; path = ../../src/optional/wren_opt_meta.h; sourceTree = "<group>"; };
+		ACDD9FB0A5CED894946F7BE7D560A786DD852951B06DE6D4 /* wren_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_utils.c; path = ../../src/vm/wren_utils.c; sourceTree = "<group>"; };
+		BB6B10F880BCD9B029698DFFD74A4422E2B88F91AFC357F0 /* wren_math.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_math.h; path = ../../src/vm/wren_math.h; sourceTree = "<group>"; };
+		C3CCDE8DECE6D43FD9E6454803F96F71DE2675BEF4156A7F /* wren.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren.h; path = ../../src/include/wren.h; sourceTree = "<group>"; };
+		C97D98CA49DA870BA0FF1DC14D4B593D8FF27031CEB7FD4B /* libwren.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libwren.a; path = libwren.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA644125737815DB6A4E4BA1CADD88CDE365E21A7CEBA41B /* wren_opt_random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_random.c; path = ../../src/optional/wren_opt_random.c; sourceTree = "<group>"; };
+		D44ABAC26F6161248D99667CE08402162CAEC553964AAF64 /* wren_primitive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_primitive.c; path = ../../src/vm/wren_primitive.c; sourceTree = "<group>"; };
+		EFCA5F4B44AC34EAD75C3B82743E03DC2071E8EC4F4B432A /* wren_debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_debug.h; path = ../../src/vm/wren_debug.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		DF84AEFB82D0382D9DA1053B /* Frameworks */ = {
+		C0AC5CFBDF84AEFBD51A440282D0382D2BAAC0B39DA1053B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -54,77 +55,78 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		046BC81407DC9A4689493E54 /* optional */ = {
+		134D909B046BC814EACF159207DC9A46D9C2680289493E54 /* optional */ = {
 			isa = PBXGroup;
 			children = (
-				62592227F4E6EC195DBF9067 /* wren_opt_meta.c */,
-				B8CA70B14B583AA3B430DEF1 /* wren_opt_meta.h */,
-				737815DBCADD88CD7CEBA41B /* wren_opt_random.c */,
-				AAEE79A50253EC97B46207E5 /* wren_opt_random.h */,
+				37890E6B62592227B630668F4E6EC19E124B99D5DBF9067 /* wren_opt_meta.c */,
+				A3605D15B8CA70B1773A55134B583AA34CFC0847B430DEF1 /* wren_opt_meta.h */,
+				CA644125737815DB6A4E4BA1CADD88CDE365E21A7CEBA41B /* wren_opt_random.c */,
+				8949E3BDAAEE79A52933EE3A0253EC97A24B84B2B46207E5 /* wren_opt_random.h */,
 			);
 			name = optional;
 			sourceTree = "<group>";
 		};
-		5E8C725002DF100215175890 /* include */ = {
+		4AEDC6106082C0DCB548161CD1C96F0E908F796E5FBBB71C /* wren */ = {
 			isa = PBXGroup;
 			children = (
-				ECE6D43F03F96F71F4156A7F /* wren.h */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		6082C0DCD1C96F0E5FBBB71C /* wren */ = {
-			isa = PBXGroup;
-			children = (
-				5E8C725002DF100215175890 /* include */,
-				046BC81407DC9A4689493E54 /* optional */,
-				7E4BAA0E72C22140C195C04E /* vm */,
-				A6C936B49B3FADE6EA134CF4 /* Products */,
+				7806C7175E8C72505F8A8A5402DF10029C2CF7B715175890 /* include */,
+				134D909B046BC814EACF159207DC9A46D9C2680289493E54 /* optional */,
+				F8B04A797E4BAA0EA893C25572C22140D4986EC5C195C04E /* vm */,
+				DE2FD571A6C936B48E134D4D9B3FADE6BA17F9BDEA134CF4 /* Products */,
 			);
 			name = wren;
 			sourceTree = "<group>";
 		};
-		7E4BAA0E72C22140C195C04E /* vm */ = {
+		7806C7175E8C72505F8A8A5402DF10029C2CF7B715175890 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				14FE11AE703F65204399AFEE /* wren_common.h */,
-				C5FFB2C8BFC16F3AF9C07108 /* wren_compiler.c */,
-				27B7A19221795E045B785FD2 /* wren_compiler.h */,
-				A24154A4F8CEBF16D147D2E4 /* wren_core.c */,
-				8BA7E8EEE2355360BAAE672E /* wren_core.h */,
-				39C26800695436F244617640 /* wren_debug.c */,
-				44AC34EA743E03DC4F4B432A /* wren_debug.h */,
-				7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */,
-				6F616124E0840216964AAF64 /* wren_primitive.c */,
-				FCC7D88E6DEA798023B126CE /* wren_primitive.h */,
-				A5CED894D560A786B06DE6D4 /* wren_utils.c */,
-				B0B8A57EE04A7470BB57B3BE /* wren_utils.h */,
-				AD30296CDCC1F85EB7CF37AC /* wren_value.c */,
-				B819F656E7ABC548C2B90496 /* wren_value.h */,
-				B65A1C18AFC01D8AA35B7A58 /* wren_vm.c */,
-				4BF57B22455B7C9438F6D962 /* wren_vm.h */,
+				C3CCDE8DECE6D43FD9E6454803F96F71DE2675BEF4156A7F /* wren.h */,
 			);
-			name = vm;
+			name = include;
 			sourceTree = "<group>";
 		};
-		A6C936B49B3FADE6EA134CF4 /* Products */ = {
+		DE2FD571A6C936B48E134D4D9B3FADE6BA17F9BDEA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				49DA870B4D4B593DCEB7FD4B /* libwren.a */,
+				C97D98CA49DA870BA0FF1DC14D4B593D8FF27031CEB7FD4B /* libwren.a */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		F8B04A797E4BAA0EA893C25572C22140D4986EC5C195C04E /* vm */ = {
+			isa = PBXGroup;
+			children = (
+				962ECC2714FE11AEA9A892E8703F65208EDF42354399AFEE /* wren_common.h */,
+				9BCFC5AC5FFB2C83E54AEEFBFC16F3A32B914CFF9C07108 /* wren_compiler.c */,
+				5A1BD6E227B7A1928EB3897721795E048317EF575B785FD2 /* wren_compiler.h */,
+				435137FAA24154A4B14FB501F8CEBF166A9EB693D147D2E4 /* wren_core.c */,
+				4DBFC1DA8BA7E8EEBBBE3EE1E2355360750D4073BAAE672E /* wren_core.h */,
+				978A996E39C268007F1C75A5695436F2C832230F44617640 /* wren_debug.c */,
+				EFCA5F4B44AC34EAD75C3B82743E03DC2071E8EC4F4B432A /* wren_debug.h */,
+				BB6B10F880BCD9B029698DFFD74A4422E2B88F91AFC357F0 /* wren_math.h */,
+				31A71877BB4B776DC20EE0CAC98AF68E9C0A3DBBFB0E5B6 /* wren_opcodes.h */,
+				D44ABAC26F6161248D99667CE08402162CAEC553964AAF64 /* wren_primitive.c */,
+				3084E635FCC7D88EE9D391F06DEA798088E8F0C723B126CE /* wren_primitive.h */,
+				ACDD9FB0A5CED894946F7BE7D560A786DD852951B06DE6D4 /* wren_utils.c */,
+				51D658DB0B8A57EECAF41C4E04A747035C4EF2EBB57B3BE /* wren_utils.h */,
+				3E0EE55AD30296CEB72CA8CDCC1F85E348877F6B7CF37AC /* wren_value.c */,
+				5C20B432B819F65643B29069E7ABC5488CC83DD3C2B90496 /* wren_value.h */,
+				6C0D5F84B65A1C1845539D81AFC01D8AD199DCD6A35B7A58 /* wren_vm.c */,
+				4DF8C9AA4BF57B22273F07A7455B7C94B38546FC38F6D962 /* wren_vm.h */,
+			);
+			name = vm;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		FC9829912B3E7D83847FD7D1 /* wren */ = {
+		442B2B3DFC9829911C27560F2B3E7D83ED176FD4847FD7D1 /* wren */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CDBFF75A710B808C8BDC4D9A /* Build configuration list for PBXNativeTarget "wren" */;
+			buildConfigurationList = C0AC5CFACDBFF75AD51A4401710B808C2BAAC0B28BDC4D9A /* Build configuration list for PBXNativeTarget "wren" */;
 			buildPhases = (
-				4F6C2F9BF2B7B8CD0D8885DB /* Resources */,
-				B91948F25C64D22477359F32 /* Sources */,
-				DF84AEFB82D0382D9DA1053B /* Frameworks */,
+				C0AC5CFF4F6C2F9BD51A4405F2B7B8CD2BAAC0B70D8885DB /* Resources */,
+				C0AC5CFFB91948F2D51A44065C64D2242BAAC0B777359F32 /* Sources */,
+				C0AC5CFBDF84AEFBD51A440282D0382D2BAAC0B39DA1053B /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -132,7 +134,7 @@
 			);
 			name = wren;
 			productName = wren;
-			productReference = 49DA870B4D4B593DCEB7FD4B /* libwren.a */;
+			productReference = C97D98CA49DA870BA0FF1DC14D4B593D8FF27031CEB7FD4B /* libwren.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -143,17 +145,17 @@
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren" */;
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 1;
-			mainGroup = 6082C0DCD1C96F0E5FBBB71C /* wren */;
+			mainGroup = 4AEDC6106082C0DCB548161CD1C96F0E908F796E5FBBB71C /* wren */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				FC9829912B3E7D83847FD7D1 /* libwren.a */,
+				442B2B3DFC9829911C27560F2B3E7D83ED176FD4847FD7D1 /* libwren.a */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		4F6C2F9BF2B7B8CD0D8885DB /* Resources */ = {
+		C0AC5CFF4F6C2F9BD51A4405F2B7B8CD2BAAC0B70D8885DB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -163,19 +165,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		B91948F25C64D22477359F32 /* Sources */ = {
+		C0AC5CFFB91948F2D51A44065C64D2242BAAC0B777359F32 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D1029E9FB01FB8D18C2914DF /* wren_opt_meta.c in Sources */,
-				032ED59302D1B8C53D266BD3 /* wren_opt_random.c in Sources */,
-				76585F8088823C32BC7325C0 /* wren_compiler.c in Sources */,
-				B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */,
-				20773D38B5EDFC6A248A5378 /* wren_debug.c in Sources */,
-				76CC0A9CBADFDBCEAEB160DC /* wren_primitive.c in Sources */,
-				8D5FBD0C22D67C3E9172D34C /* wren_utils.c in Sources */,
-				E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */,
-				7FA807D04313C98281B76E10 /* wren_vm.c in Sources */,
+				A6EE846CD1029E9F3EBA59DCB01FB8D1FD8A127C8C2914DF /* wren_opt_meta.c in Sources */,
+				6FD1F8C0032ED593B68B31602D1B8C5A6A130ED3D266BD3 /* wren_opt_random.c in Sources */,
+				D8C7769676585F8051FD19D088823C323E62AA02BC7325C0 /* wren_compiler.c in Sources */,
+				FA6E4000B9CCD11CC1FC4534EBC61BCE42ED671C65A5575C /* wren_core.c in Sources */,
+				8E2BFBF320773D3871501EFBB5EDFC6AF31158A9248A5378 /* wren_debug.c in Sources */,
+				9601678D76CC0A9C332CC194BADFDBCECF372723AEB160DC /* wren_primitive.c in Sources */,
+				9A07EECA8D5FBD0C7D2C11D322D67C3EFEED4B809172D34C /* wren_utils.c in Sources */,
+				51FC59E1DB0F64E3761F627751CE966537590FE5EE25A4 /* wren_value.c in Sources */,
+				6C4ADE87FA807D089774CD54313C9821583E5BC81B76E10 /* wren_vm.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -185,13 +187,25 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		2FCCE8EB6887AF5DF81EE72B /* Debug */ = {
+		184BF2BB4597E320D5CFC7F98E08C75267103C62D2A79960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = ../../lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = wren_d;
+			};
+			name = Debug;
+		};
+		2334C0512FCCE8EBCFEE981C6887AF5D5BB86A90F81EE72B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
 				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
 				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_C_LANGUAGE_STANDARD = C99;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -212,7 +226,7 @@
 			};
 			name = Debug;
 		};
-		4597E3208E08C752D2A79960 /* Debug */ = {
+		7DC8BE9451E0461AAB96DC867A1AFECC8EC6105361B68C5A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -220,16 +234,16 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/lib;
-				PRODUCT_NAME = wren_d;
+				PRODUCT_NAME = wren;
 			};
-			name = Debug;
+			name = Release;
 		};
-		4B12A9E59D98D4D76FDD3825 /* Release */ = {
+		C3B253024B12A9E586414A7E9D98D4D72BC98C556FDD3825 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
 				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
-				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_C_LANGUAGE_STANDARD = C99;
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					NDEBUG,
@@ -249,43 +263,31 @@
 			};
 			name = Release;
 		};
-		51E0461A7A1AFECC61B68C5A /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = ../../lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_DYNAMIC_NO_PIC = NO;
-				INSTALL_PATH = /usr/local/lib;
-				PRODUCT_NAME = wren;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
 		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4B12A9E59D98D4D76FDD3825 /* Release */,
-				4B12A9E59D98D4D76FDD3825 /* Release */,
-				4B12A9E59D98D4D76FDD3825 /* Release */,
-				2FCCE8EB6887AF5DF81EE72B /* Debug */,
-				2FCCE8EB6887AF5DF81EE72B /* Debug */,
-				2FCCE8EB6887AF5DF81EE72B /* Debug */,
+				C3B253024B12A9E586414A7E9D98D4D72BC98C556FDD3825 /* Release */,
+				C3B253024B12A9E586414A7E9D98D4D72BC98C556FDD3825 /* Release */,
+				C3B253024B12A9E586414A7E9D98D4D72BC98C556FDD3825 /* Release */,
+				2334C0512FCCE8EBCFEE981C6887AF5D5BB86A90F81EE72B /* Debug */,
+				2334C0512FCCE8EBCFEE981C6887AF5D5BB86A90F81EE72B /* Debug */,
+				2334C0512FCCE8EBCFEE981C6887AF5D5BB86A90F81EE72B /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CDBFF75A710B808C8BDC4D9A /* Build configuration list for PBXNativeTarget "libwren.a" */ = {
+		C0AC5CFACDBFF75AD51A4401710B808C2BAAC0B28BDC4D9A /* Build configuration list for PBXNativeTarget "libwren.a" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				51E0461A7A1AFECC61B68C5A /* Release */,
-				51E0461A7A1AFECC61B68C5A /* Release */,
-				51E0461A7A1AFECC61B68C5A /* Release */,
-				4597E3208E08C752D2A79960 /* Debug */,
-				4597E3208E08C752D2A79960 /* Debug */,
-				4597E3208E08C752D2A79960 /* Debug */,
+				7DC8BE9451E0461AAB96DC867A1AFECC8EC6105361B68C5A /* Release */,
+				7DC8BE9451E0461AAB96DC867A1AFECC8EC6105361B68C5A /* Release */,
+				7DC8BE9451E0461AAB96DC867A1AFECC8EC6105361B68C5A /* Release */,
+				184BF2BB4597E320D5CFC7F98E08C75267103C62D2A79960 /* Debug */,
+				184BF2BB4597E320D5CFC7F98E08C75267103C62D2A79960 /* Debug */,
+				184BF2BB4597E320D5CFC7F98E08C75267103C62D2A79960 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/projects/xcode/wren.xcworkspace/contents.xcworkspacedata
+++ b/projects/xcode/wren.xcworkspace/contents.xcworkspacedata
@@ -2,12 +2,12 @@
 <Workspace
 	version = "1.0">
 	<FileRef
-		location = "group:wren_test.xcodeproj">
-	</FileRef>
-	<FileRef
 		location = "group:wren.xcodeproj">
 	</FileRef>
 	<FileRef
 		location = "group:wren_shared.xcodeproj">
+	</FileRef>
+	<FileRef
+		location = "group:wren_test.xcodeproj">
 	</FileRef>
 </Workspace>

--- a/projects/xcode/wren_shared.xcodeproj/project.pbxproj
+++ b/projects/xcode/wren_shared.xcodeproj/project.pbxproj
@@ -7,44 +7,45 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		032ED59302D1B8C53D266BD3 /* wren_opt_random.c in Sources */ = {isa = PBXBuildFile; fileRef = 737815DBCADD88CD7CEBA41B /* wren_opt_random.c */; };
-		20773D38B5EDFC6A248A5378 /* wren_debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 39C26800695436F244617640 /* wren_debug.c */; };
-		76585F8088823C32BC7325C0 /* wren_compiler.c in Sources */ = {isa = PBXBuildFile; fileRef = C5FFB2C8BFC16F3AF9C07108 /* wren_compiler.c */; };
-		76CC0A9CBADFDBCEAEB160DC /* wren_primitive.c in Sources */ = {isa = PBXBuildFile; fileRef = 6F616124E0840216964AAF64 /* wren_primitive.c */; };
-		7FA807D04313C98281B76E10 /* wren_vm.c in Sources */ = {isa = PBXBuildFile; fileRef = B65A1C18AFC01D8AA35B7A58 /* wren_vm.c */; };
-		8D5FBD0C22D67C3E9172D34C /* wren_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A5CED894D560A786B06DE6D4 /* wren_utils.c */; };
-		B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */ = {isa = PBXBuildFile; fileRef = A24154A4F8CEBF16D147D2E4 /* wren_core.c */; };
-		D1029E9FB01FB8D18C2914DF /* wren_opt_meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 62592227F4E6EC195DBF9067 /* wren_opt_meta.c */; };
-		E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */ = {isa = PBXBuildFile; fileRef = AD30296CDCC1F85EB7CF37AC /* wren_value.c */; };
+		51FC59E1DB0F64E3761F627751CE966537590FE5EE25A4 /* wren_value.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E0EE55AD30296CEB72CA8CDCC1F85E348877F6B7CF37AC /* wren_value.c */; };
+		6C4ADE87FA807D089774CD54313C9821583E5BC81B76E10 /* wren_vm.c in Sources */ = {isa = PBXBuildFile; fileRef = 6C0D5F84B65A1C1845539D81AFC01D8AD199DCD6A35B7A58 /* wren_vm.c */; };
+		6FD1F8C0032ED593B68B31602D1B8C5A6A130ED3D266BD3 /* wren_opt_random.c in Sources */ = {isa = PBXBuildFile; fileRef = CA644125737815DB6A4E4BA1CADD88CDE365E21A7CEBA41B /* wren_opt_random.c */; };
+		8E2BFBF320773D3871501EFBB5EDFC6AF31158A9248A5378 /* wren_debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 978A996E39C268007F1C75A5695436F2C832230F44617640 /* wren_debug.c */; };
+		9601678D76CC0A9C332CC194BADFDBCECF372723AEB160DC /* wren_primitive.c in Sources */ = {isa = PBXBuildFile; fileRef = D44ABAC26F6161248D99667CE08402162CAEC553964AAF64 /* wren_primitive.c */; };
+		9A07EECA8D5FBD0C7D2C11D322D67C3EFEED4B809172D34C /* wren_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = ACDD9FB0A5CED894946F7BE7D560A786DD852951B06DE6D4 /* wren_utils.c */; };
+		A6EE846CD1029E9F3EBA59DCB01FB8D1FD8A127C8C2914DF /* wren_opt_meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 37890E6B62592227B630668F4E6EC19E124B99D5DBF9067 /* wren_opt_meta.c */; };
+		D8C7769676585F8051FD19D088823C323E62AA02BC7325C0 /* wren_compiler.c in Sources */ = {isa = PBXBuildFile; fileRef = 9BCFC5AC5FFB2C83E54AEEFBFC16F3A32B914CFF9C07108 /* wren_compiler.c */; };
+		FA6E4000B9CCD11CC1FC4534EBC61BCE42ED671C65A5575C /* wren_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 435137FAA24154A4B14FB501F8CEBF166A9EB693D147D2E4 /* wren_core.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		14FE11AE703F65204399AFEE /* wren_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_common.h; path = ../../src/vm/wren_common.h; sourceTree = "<group>"; };
-		27B7A19221795E045B785FD2 /* wren_compiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_compiler.h; path = ../../src/vm/wren_compiler.h; sourceTree = "<group>"; };
-		39C26800695436F244617640 /* wren_debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_debug.c; path = ../../src/vm/wren_debug.c; sourceTree = "<group>"; };
-		44AC34EA743E03DC4F4B432A /* wren_debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_debug.h; path = ../../src/vm/wren_debug.h; sourceTree = "<group>"; };
-		4BF57B22455B7C9438F6D962 /* wren_vm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_vm.h; path = ../../src/vm/wren_vm.h; sourceTree = "<group>"; };
-		62592227F4E6EC195DBF9067 /* wren_opt_meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_meta.c; path = ../../src/optional/wren_opt_meta.c; sourceTree = "<group>"; };
-		6F616124E0840216964AAF64 /* wren_primitive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_primitive.c; path = ../../src/vm/wren_primitive.c; sourceTree = "<group>"; };
-		737815DBCADD88CD7CEBA41B /* wren_opt_random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_random.c; path = ../../src/optional/wren_opt_random.c; sourceTree = "<group>"; };
-		7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opcodes.h; path = ../../src/vm/wren_opcodes.h; sourceTree = "<group>"; };
-		89E69C5EA0F937909115329E /* libwren.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libwren.dylib; path = libwren.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		8BA7E8EEE2355360BAAE672E /* wren_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_core.h; path = ../../src/vm/wren_core.h; sourceTree = "<group>"; };
-		A24154A4F8CEBF16D147D2E4 /* wren_core.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_core.c; path = ../../src/vm/wren_core.c; sourceTree = "<group>"; };
-		A5CED894D560A786B06DE6D4 /* wren_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_utils.c; path = ../../src/vm/wren_utils.c; sourceTree = "<group>"; };
-		AAEE79A50253EC97B46207E5 /* wren_opt_random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_random.h; path = ../../src/optional/wren_opt_random.h; sourceTree = "<group>"; };
-		AD30296CDCC1F85EB7CF37AC /* wren_value.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_value.c; path = ../../src/vm/wren_value.c; sourceTree = "<group>"; };
-		B0B8A57EE04A7470BB57B3BE /* wren_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_utils.h; path = ../../src/vm/wren_utils.h; sourceTree = "<group>"; };
-		B65A1C18AFC01D8AA35B7A58 /* wren_vm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_vm.c; path = ../../src/vm/wren_vm.c; sourceTree = "<group>"; };
-		B819F656E7ABC548C2B90496 /* wren_value.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_value.h; path = ../../src/vm/wren_value.h; sourceTree = "<group>"; };
-		B8CA70B14B583AA3B430DEF1 /* wren_opt_meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_meta.h; path = ../../src/optional/wren_opt_meta.h; sourceTree = "<group>"; };
-		C5FFB2C8BFC16F3AF9C07108 /* wren_compiler.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_compiler.c; path = ../../src/vm/wren_compiler.c; sourceTree = "<group>"; };
-		ECE6D43F03F96F71F4156A7F /* wren.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren.h; path = ../../src/include/wren.h; sourceTree = "<group>"; };
-		FCC7D88E6DEA798023B126CE /* wren_primitive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_primitive.h; path = ../../src/vm/wren_primitive.h; sourceTree = "<group>"; };
+		3084E635FCC7D88EE9D391F06DEA798088E8F0C723B126CE /* wren_primitive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_primitive.h; path = ../../src/vm/wren_primitive.h; sourceTree = "<group>"; };
+		31A71877BB4B776DC20EE0CAC98AF68E9C0A3DBBFB0E5B6 /* wren_opcodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opcodes.h; path = ../../src/vm/wren_opcodes.h; sourceTree = "<group>"; };
+		37890E6B62592227B630668F4E6EC19E124B99D5DBF9067 /* wren_opt_meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_meta.c; path = ../../src/optional/wren_opt_meta.c; sourceTree = "<group>"; };
+		3E0EE55AD30296CEB72CA8CDCC1F85E348877F6B7CF37AC /* wren_value.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_value.c; path = ../../src/vm/wren_value.c; sourceTree = "<group>"; };
+		435137FAA24154A4B14FB501F8CEBF166A9EB693D147D2E4 /* wren_core.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_core.c; path = ../../src/vm/wren_core.c; sourceTree = "<group>"; };
+		4DBFC1DA8BA7E8EEBBBE3EE1E2355360750D4073BAAE672E /* wren_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_core.h; path = ../../src/vm/wren_core.h; sourceTree = "<group>"; };
+		4DF8C9AA4BF57B22273F07A7455B7C94B38546FC38F6D962 /* wren_vm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_vm.h; path = ../../src/vm/wren_vm.h; sourceTree = "<group>"; };
+		51D658DB0B8A57EECAF41C4E04A747035C4EF2EBB57B3BE /* wren_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_utils.h; path = ../../src/vm/wren_utils.h; sourceTree = "<group>"; };
+		5A1BD6E227B7A1928EB3897721795E048317EF575B785FD2 /* wren_compiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_compiler.h; path = ../../src/vm/wren_compiler.h; sourceTree = "<group>"; };
+		5C20B432B819F65643B29069E7ABC5488CC83DD3C2B90496 /* wren_value.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_value.h; path = ../../src/vm/wren_value.h; sourceTree = "<group>"; };
+		6C0D5F84B65A1C1845539D81AFC01D8AD199DCD6A35B7A58 /* wren_vm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_vm.c; path = ../../src/vm/wren_vm.c; sourceTree = "<group>"; };
+		8949E3BDAAEE79A52933EE3A0253EC97A24B84B2B46207E5 /* wren_opt_random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_random.h; path = ../../src/optional/wren_opt_random.h; sourceTree = "<group>"; };
+		962ECC2714FE11AEA9A892E8703F65208EDF42354399AFEE /* wren_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_common.h; path = ../../src/vm/wren_common.h; sourceTree = "<group>"; };
+		978A996E39C268007F1C75A5695436F2C832230F44617640 /* wren_debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_debug.c; path = ../../src/vm/wren_debug.c; sourceTree = "<group>"; };
+		9BCFC5AC5FFB2C83E54AEEFBFC16F3A32B914CFF9C07108 /* wren_compiler.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_compiler.c; path = ../../src/vm/wren_compiler.c; sourceTree = "<group>"; };
+		A3605D15B8CA70B1773A55134B583AA34CFC0847B430DEF1 /* wren_opt_meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_opt_meta.h; path = ../../src/optional/wren_opt_meta.h; sourceTree = "<group>"; };
+		ACDD9FB0A5CED894946F7BE7D560A786DD852951B06DE6D4 /* wren_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_utils.c; path = ../../src/vm/wren_utils.c; sourceTree = "<group>"; };
+		BB6B10F880BCD9B029698DFFD74A4422E2B88F91AFC357F0 /* wren_math.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_math.h; path = ../../src/vm/wren_math.h; sourceTree = "<group>"; };
+		C3CCDE8DECE6D43FD9E6454803F96F71DE2675BEF4156A7F /* wren.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren.h; path = ../../src/include/wren.h; sourceTree = "<group>"; };
+		CA644125737815DB6A4E4BA1CADD88CDE365E21A7CEBA41B /* wren_opt_random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_opt_random.c; path = ../../src/optional/wren_opt_random.c; sourceTree = "<group>"; };
+		D44ABAC26F6161248D99667CE08402162CAEC553964AAF64 /* wren_primitive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = wren_primitive.c; path = ../../src/vm/wren_primitive.c; sourceTree = "<group>"; };
+		EFCA5F4B44AC34EAD75C3B82743E03DC2071E8EC4F4B432A /* wren_debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = wren_debug.h; path = ../../src/vm/wren_debug.h; sourceTree = "<group>"; };
+		F73C1BAA89E69C5ED558264A0F937901195B2DB9115329E /* libwren.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libwren.dylib; path = libwren.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		7D2D12CE809DE500020A890E /* Frameworks */ = {
+		114A91EE7D2D12CEE8CC16E5809DE500D7BF6956020A890E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -54,77 +55,78 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		046BC81407DC9A4689493E54 /* optional */ = {
+		134D909B046BC814EACF159207DC9A46D9C2680289493E54 /* optional */ = {
 			isa = PBXGroup;
 			children = (
-				62592227F4E6EC195DBF9067 /* wren_opt_meta.c */,
-				B8CA70B14B583AA3B430DEF1 /* wren_opt_meta.h */,
-				737815DBCADD88CD7CEBA41B /* wren_opt_random.c */,
-				AAEE79A50253EC97B46207E5 /* wren_opt_random.h */,
+				37890E6B62592227B630668F4E6EC19E124B99D5DBF9067 /* wren_opt_meta.c */,
+				A3605D15B8CA70B1773A55134B583AA34CFC0847B430DEF1 /* wren_opt_meta.h */,
+				CA644125737815DB6A4E4BA1CADD88CDE365E21A7CEBA41B /* wren_opt_random.c */,
+				8949E3BDAAEE79A52933EE3A0253EC97A24B84B2B46207E5 /* wren_opt_random.h */,
 			);
 			name = optional;
 			sourceTree = "<group>";
 		};
-		5E8C725002DF100215175890 /* include */ = {
+		7806C7175E8C72505F8A8A5402DF10029C2CF7B715175890 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				ECE6D43F03F96F71F4156A7F /* wren.h */,
+				C3CCDE8DECE6D43FD9E6454803F96F71DE2675BEF4156A7F /* wren.h */,
 			);
 			name = include;
 			sourceTree = "<group>";
 		};
-		7E4BAA0E72C22140C195C04E /* vm */ = {
+		8BE7350ED82C1CD296A3E917423E9EC4D2B6AAC0DB698B12 /* wren_shared */ = {
 			isa = PBXGroup;
 			children = (
-				14FE11AE703F65204399AFEE /* wren_common.h */,
-				C5FFB2C8BFC16F3AF9C07108 /* wren_compiler.c */,
-				27B7A19221795E045B785FD2 /* wren_compiler.h */,
-				A24154A4F8CEBF16D147D2E4 /* wren_core.c */,
-				8BA7E8EEE2355360BAAE672E /* wren_core.h */,
-				39C26800695436F244617640 /* wren_debug.c */,
-				44AC34EA743E03DC4F4B432A /* wren_debug.h */,
-				7BB4B776AC98AF68BFB0E5B6 /* wren_opcodes.h */,
-				6F616124E0840216964AAF64 /* wren_primitive.c */,
-				FCC7D88E6DEA798023B126CE /* wren_primitive.h */,
-				A5CED894D560A786B06DE6D4 /* wren_utils.c */,
-				B0B8A57EE04A7470BB57B3BE /* wren_utils.h */,
-				AD30296CDCC1F85EB7CF37AC /* wren_value.c */,
-				B819F656E7ABC548C2B90496 /* wren_value.h */,
-				B65A1C18AFC01D8AA35B7A58 /* wren_vm.c */,
-				4BF57B22455B7C9438F6D962 /* wren_vm.h */,
+				7806C7175E8C72505F8A8A5402DF10029C2CF7B715175890 /* include */,
+				134D909B046BC814EACF159207DC9A46D9C2680289493E54 /* optional */,
+				F8B04A797E4BAA0EA893C25572C22140D4986EC5C195C04E /* vm */,
+				DE2FD571A6C936B48E134D4D9B3FADE6BA17F9BDEA134CF4 /* Products */,
 			);
-			name = vm;
+			name = wren_shared;
 			sourceTree = "<group>";
 		};
-		A6C936B49B3FADE6EA134CF4 /* Products */ = {
+		DE2FD571A6C936B48E134D4D9B3FADE6BA17F9BDEA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				89E69C5EA0F937909115329E /* libwren.dylib */,
+				F73C1BAA89E69C5ED558264A0F937901195B2DB9115329E /* libwren.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D82C1CD2423E9EC4DB698B12 /* wren_shared */ = {
+		F8B04A797E4BAA0EA893C25572C22140D4986EC5C195C04E /* vm */ = {
 			isa = PBXGroup;
 			children = (
-				5E8C725002DF100215175890 /* include */,
-				046BC81407DC9A4689493E54 /* optional */,
-				7E4BAA0E72C22140C195C04E /* vm */,
-				A6C936B49B3FADE6EA134CF4 /* Products */,
+				962ECC2714FE11AEA9A892E8703F65208EDF42354399AFEE /* wren_common.h */,
+				9BCFC5AC5FFB2C83E54AEEFBFC16F3A32B914CFF9C07108 /* wren_compiler.c */,
+				5A1BD6E227B7A1928EB3897721795E048317EF575B785FD2 /* wren_compiler.h */,
+				435137FAA24154A4B14FB501F8CEBF166A9EB693D147D2E4 /* wren_core.c */,
+				4DBFC1DA8BA7E8EEBBBE3EE1E2355360750D4073BAAE672E /* wren_core.h */,
+				978A996E39C268007F1C75A5695436F2C832230F44617640 /* wren_debug.c */,
+				EFCA5F4B44AC34EAD75C3B82743E03DC2071E8EC4F4B432A /* wren_debug.h */,
+				BB6B10F880BCD9B029698DFFD74A4422E2B88F91AFC357F0 /* wren_math.h */,
+				31A71877BB4B776DC20EE0CAC98AF68E9C0A3DBBFB0E5B6 /* wren_opcodes.h */,
+				D44ABAC26F6161248D99667CE08402162CAEC553964AAF64 /* wren_primitive.c */,
+				3084E635FCC7D88EE9D391F06DEA798088E8F0C723B126CE /* wren_primitive.h */,
+				ACDD9FB0A5CED894946F7BE7D560A786DD852951B06DE6D4 /* wren_utils.c */,
+				51D658DB0B8A57EECAF41C4E04A747035C4EF2EBB57B3BE /* wren_utils.h */,
+				3E0EE55AD30296CEB72CA8CDCC1F85E348877F6B7CF37AC /* wren_value.c */,
+				5C20B432B819F65643B29069E7ABC5488CC83DD3C2B90496 /* wren_value.h */,
+				6C0D5F84B65A1C1845539D81AFC01D8AD199DCD6A35B7A58 /* wren_vm.c */,
+				4DF8C9AA4BF57B22273F07A7455B7C94B38546FC38F6D962 /* wren_vm.h */,
 			);
-			name = wren_shared;
+			name = vm;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		CFFD6084D0B05D7644922EC4 /* wren_shared */ = {
+		5511E963CFFD6084D1DC60DDD0B05D766D24244644922EC4 /* wren_shared */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6B685B2D6ED92D5FF045D16D /* Build configuration list for PBXNativeTarget "wren_shared" */;
+			buildConfigurationList = 114A91ED6B685B2DE8CC16E46ED92D5FD7BF6954F045D16D /* Build configuration list for PBXNativeTarget "wren_shared" */;
 			buildPhases = (
-				ED14936EF08565A071F209AE /* Resources */,
-				56C1ACC55A327EF7DB9F2305 /* Sources */,
-				7D2D12CE809DE500020A890E /* Frameworks */,
+				114A91F1ED14936EE8CC16E8F08565A0D7BF695971F209AE /* Resources */,
+				114A91F256C1ACC5E8CC16E95A327EF7D7BF6959DB9F2305 /* Sources */,
+				114A91EE7D2D12CEE8CC16E5809DE500D7BF6956020A890E /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -132,7 +134,7 @@
 			);
 			name = wren_shared;
 			productName = wren_shared;
-			productReference = 89E69C5EA0F937909115329E /* libwren.dylib */;
+			productReference = F73C1BAA89E69C5ED558264A0F937901195B2DB9115329E /* libwren.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -143,17 +145,17 @@
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren_shared" */;
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 1;
-			mainGroup = D82C1CD2423E9EC4DB698B12 /* wren_shared */;
+			mainGroup = 8BE7350ED82C1CD296A3E917423E9EC4D2B6AAC0DB698B12 /* wren_shared */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CFFD6084D0B05D7644922EC4 /* libwren.dylib */,
+				5511E963CFFD6084D1DC60DDD0B05D766D24244644922EC4 /* libwren.dylib */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		ED14936EF08565A071F209AE /* Resources */ = {
+		114A91F1ED14936EE8CC16E8F08565A0D7BF695971F209AE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -163,19 +165,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		56C1ACC55A327EF7DB9F2305 /* Sources */ = {
+		114A91F256C1ACC5E8CC16E95A327EF7D7BF6959DB9F2305 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D1029E9FB01FB8D18C2914DF /* wren_opt_meta.c in Sources */,
-				032ED59302D1B8C53D266BD3 /* wren_opt_random.c in Sources */,
-				76585F8088823C32BC7325C0 /* wren_compiler.c in Sources */,
-				B9CCD11CEBC61BCE65A5575C /* wren_core.c in Sources */,
-				20773D38B5EDFC6A248A5378 /* wren_debug.c in Sources */,
-				76CC0A9CBADFDBCEAEB160DC /* wren_primitive.c in Sources */,
-				8D5FBD0C22D67C3E9172D34C /* wren_utils.c in Sources */,
-				E1DB0F647751CE96E5EE25A4 /* wren_value.c in Sources */,
-				7FA807D04313C98281B76E10 /* wren_vm.c in Sources */,
+				A6EE846CD1029E9F3EBA59DCB01FB8D1FD8A127C8C2914DF /* wren_opt_meta.c in Sources */,
+				6FD1F8C0032ED593B68B31602D1B8C5A6A130ED3D266BD3 /* wren_opt_random.c in Sources */,
+				D8C7769676585F8051FD19D088823C323E62AA02BC7325C0 /* wren_compiler.c in Sources */,
+				FA6E4000B9CCD11CC1FC4534EBC61BCE42ED671C65A5575C /* wren_core.c in Sources */,
+				8E2BFBF320773D3871501EFBB5EDFC6AF31158A9248A5378 /* wren_debug.c in Sources */,
+				9601678D76CC0A9C332CC194BADFDBCECF372723AEB160DC /* wren_primitive.c in Sources */,
+				9A07EECA8D5FBD0C7D2C11D322D67C3EFEED4B809172D34C /* wren_utils.c in Sources */,
+				51FC59E1DB0F64E3761F627751CE966537590FE5EE25A4 /* wren_value.c in Sources */,
+				6C4ADE87FA807D089774CD54313C9821583E5BC81B76E10 /* wren_vm.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -185,64 +187,13 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		9328E01B361706CDC53CE65B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
-				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
-				GCC_C_LANGUAGE_STANDARD = c99;
-				GCC_OPTIMIZATION_LEVEL = 3;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					NDEBUG,
-					"WREN_NAN_TAGGING=0",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = "obj/64bit-no-nan-tagging/Release/wren_shared";
-				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = ../../lib;
-				USER_HEADER_SEARCH_PATHS = (
-					../../src/include,
-					../../src/vm,
-					../../src/optional,
-				);
-			};
-			name = Release;
-		};
-		CB419B73ED0D48A529C271B3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = ../../lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				EXECUTABLE_PREFIX = lib;
-				GCC_DYNAMIC_NO_PIC = NO;
-				INSTALL_PATH = /usr/local/lib;
-				PRODUCT_NAME = wren_d;
-			};
-			name = Debug;
-		};
-		E8D95F2DAC4520DFEAE8C56D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = ../../lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				EXECUTABLE_PREFIX = lib;
-				GCC_DYNAMIC_NO_PIC = NO;
-				INSTALL_PATH = /usr/local/lib;
-				PRODUCT_NAME = wren;
-			};
-			name = Release;
-		};
-		F95419A1FCC4EBD37E318FE1 /* Debug */ = {
+		21D944D6F95419A1F95AC9CDFCC4EBD3E84E1C3E7E318FE1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
 				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
 				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_C_LANGUAGE_STANDARD = C99;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -263,31 +214,82 @@
 			};
 			name = Debug;
 		};
+		2EE32E69CB419B738B09186ED0D48A5747BEC2C29C271B3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = ../../lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = lib;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = wren_d;
+			};
+			name = Debug;
+		};
+		971D9FFAE8D95F2D19D03EE7AC4520DFA5DCD7CEEAE8C56D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = ../../lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = lib;
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/lib;
+				PRODUCT_NAME = wren;
+			};
+			name = Release;
+		};
+		FD8A10209328E01BBB80AEE6361706CD34925F7CC53CE65B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = C99;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					"WREN_NAN_TAGGING=0",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = "obj/64bit-no-nan-tagging/Release/wren_shared";
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = ../../lib;
+				USER_HEADER_SEARCH_PATHS = (
+					../../src/include,
+					../../src/vm,
+					../../src/optional,
+				);
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren_shared" */ = {
+		114A91ED6B685B2DE8CC16E46ED92D5FD7BF6954F045D16D /* Build configuration list for PBXNativeTarget "libwren.dylib" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9328E01B361706CDC53CE65B /* Release */,
-				9328E01B361706CDC53CE65B /* Release */,
-				9328E01B361706CDC53CE65B /* Release */,
-				F95419A1FCC4EBD37E318FE1 /* Debug */,
-				F95419A1FCC4EBD37E318FE1 /* Debug */,
-				F95419A1FCC4EBD37E318FE1 /* Debug */,
+				971D9FFAE8D95F2D19D03EE7AC4520DFA5DCD7CEEAE8C56D /* Release */,
+				971D9FFAE8D95F2D19D03EE7AC4520DFA5DCD7CEEAE8C56D /* Release */,
+				971D9FFAE8D95F2D19D03EE7AC4520DFA5DCD7CEEAE8C56D /* Release */,
+				2EE32E69CB419B738B09186ED0D48A5747BEC2C29C271B3 /* Debug */,
+				2EE32E69CB419B738B09186ED0D48A5747BEC2C29C271B3 /* Debug */,
+				2EE32E69CB419B738B09186ED0D48A5747BEC2C29C271B3 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6B685B2D6ED92D5FF045D16D /* Build configuration list for PBXNativeTarget "libwren.dylib" */ = {
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren_shared" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E8D95F2DAC4520DFEAE8C56D /* Release */,
-				E8D95F2DAC4520DFEAE8C56D /* Release */,
-				E8D95F2DAC4520DFEAE8C56D /* Release */,
-				CB419B73ED0D48A529C271B3 /* Debug */,
-				CB419B73ED0D48A529C271B3 /* Debug */,
-				CB419B73ED0D48A529C271B3 /* Debug */,
+				FD8A10209328E01BBB80AEE6361706CD34925F7CC53CE65B /* Release */,
+				FD8A10209328E01BBB80AEE6361706CD34925F7CC53CE65B /* Release */,
+				FD8A10209328E01BBB80AEE6361706CD34925F7CC53CE65B /* Release */,
+				21D944D6F95419A1F95AC9CDFCC4EBD3E84E1C3E7E318FE1 /* Debug */,
+				21D944D6F95419A1F95AC9CDFCC4EBD3E84E1C3E7E318FE1 /* Debug */,
+				21D944D6F95419A1F95AC9CDFCC4EBD3E84E1C3E7E318FE1 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/projects/xcode/wren_test.xcodeproj/project.pbxproj
+++ b/projects/xcode/wren_test.xcodeproj/project.pbxproj
@@ -7,199 +7,204 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		134AABB542DC7AA71DE9B9F5 /* slots.c in Sources */ = {isa = PBXBuildFile; fileRef = 33526D1DD64093CF6566735D /* slots.c */; };
-		181D16496F82893B2190A489 /* foreign_class.c in Sources */ = {isa = PBXBuildFile; fileRef = 8A4FC471BC490F2336284AB1 /* foreign_class.c */; };
-		1C5491694BE6605B26F39FA9 /* lists.c in Sources */ = {isa = PBXBuildFile; fileRef = 41058591E3F3AC4373198BD1 /* lists.c */; };
-		29C70EE3850862555862AD23 /* new_vm.c in Sources */ = {isa = PBXBuildFile; fileRef = C22EBF6BD9415A9DC95D55AB /* new_vm.c */; };
-		31D07E222B367F941ED1DC62 /* test.c in Sources */ = {isa = PBXBuildFile; fileRef = 7B2F762A1E7AFF5C394BCC6A /* test.c */; };
-		47E53E839E72A8F576EBBCC3 /* call.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F776B0B32E83D3DB454E14B /* call.c */; };
-		4D8AE463A8CC37D57C2682A3 /* handle.c in Sources */ = {isa = PBXBuildFile; fileRef = 069BFCEB1DAE981D0DCA932B /* handle.c */; };
-		4EA04F0DA52DB97F7DA6CD4D /* maps.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AEABBF53E5B8E27BFC83235 /* maps.c */; };
-		59615B339DB000A5DFD73973 /* resolution.c in Sources */ = {isa = PBXBuildFile; fileRef = 535262BB751E0FEDB1D338FB /* resolution.c */; };
-		78667B8C71CC7CFE6567D9CC /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E0F7DF4115B07262C2BD434 /* main.c */; };
-		7CCD7163EDF01255A3B6BFA3 /* api_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = 21B810EB49F2C99D318E572B /* api_tests.c */; };
-		8F510F77A173C5697A74FDB7 /* reset_stack_after_foreign_construct.c in Sources */ = {isa = PBXBuildFile; fileRef = 310165BFD4689371EB9E4BFF /* reset_stack_after_foreign_construct.c */; };
-		A9B950DFD94B1FD1B4585F1F /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = F961FEA79C5025592B7604E7 /* error.c */; };
-		AA2E14D19E2D5E4323187311 /* call_calls_foreign.c in Sources */ = {isa = PBXBuildFile; fileRef = 93074179D71B12ABCAEC97B9 /* call_calls_foreign.c */; };
-		BD0CC4E181C21B533630C321 /* reset_stack_after_call_abort.c in Sources */ = {isa = PBXBuildFile; fileRef = B1B12E89FA506CBB1D7C24C9 /* reset_stack_after_call_abort.c */; };
-		D43547E14557E8D3FB1E9621 /* benchmark.c in Sources */ = {isa = PBXBuildFile; fileRef = 50338489786E3D3B6009CAC9 /* benchmark.c */; };
-		DA534BB5CB4AB9A7374E39F5 /* call_wren_call_root.c in Sources */ = {isa = PBXBuildFile; fileRef = F9C7671D92144CCFC05B4D5D /* call_wren_call_root.c */; };
-		DAAEBD7B4BD15E6D01980BBB /* user_data.c in Sources */ = {isa = PBXBuildFile; fileRef = B0175F83D8521835BFEDA5C3 /* user_data.c */; };
-		E21864B54F40732750D362F5 /* get_variable.c in Sources */ = {isa = PBXBuildFile; fileRef = 1270B31D5FD3A94FD5F2A95D /* get_variable.c */; };
-		F97FE7C03DCE8D327FF5C600 /* libwren.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F5D0B9A8179C66DA54518FE8 /* libwren.a */; };
+		11FA61CA4EA04F0D7FF8DED1A52DB97F3947E0637DA6CD4D /* maps.c in Sources */ = {isa = PBXBuildFile; fileRef = CD409FE83AEABBF5A4C224DF3E5B8E2793B5774FBFC83235 /* maps.c */; };
+		2891C992D43547E1E1E0754D4557E8D380F5D423FB1E9621 /* benchmark.c in Sources */ = {isa = PBXBuildFile; fileRef = 63BED14F50338489918CEF41786E3D3B74BC230E6009CAC9 /* benchmark.c */; };
+		37617F4259615B337F0A035D9DB000A538F272B8DFD73973 /* resolution.c in Sources */ = {isa = PBXBuildFile; fileRef = C98A7702535262BBA357DA1F751E0FEDF2334C4B1D338FB /* resolution.c */; };
+		39CD4A40134AABB5215F267742DC7AA76A74D3E11DE9B9F5 /* slots.c in Sources */ = {isa = PBXBuildFile; fileRef = 23A6011D33526D1DE19C9FE2D64093CF5AAE50796566735D /* slots.c */; };
+		3E2E0CA87CCD7163F77CB862EDF0125596921739A3B6BFA3 /* api_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = 12758C4F21B810EB4043AA4149F2C99D2372DE0E318E572B /* api_tests.c */; };
+		42DA56B1181D1649E2C4612D6F82893B5BDBF7A62190A489 /* foreign_class.c in Sources */ = {isa = PBXBuildFile; fileRef = 3733EC4F8A4FC471FEC1F183BC490F237FB3136B36284AB1 /* foreign_class.c */; };
+		47D2884EE21864B57A0A75FB4F407327C705C7ED50D362F5 /* get_variable.c in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B8301270B31D37FC55B5FD3A94FC516350CD5F2A95D /* get_variable.c */; };
+		4C4F423378667B8C2595803071CC7CFEB1DBBF856567D9CC /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 83AB881F6E0F7DF498196F26115B0726EEA9EBD72C2BD434 /* main.c */; };
+		4D524052DAAEBD7B6A0EC0D4BD15E6DA5B64AE401980BBB /* user_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 6F860494B0175F839D542286D852183580835653BFEDA5C3 /* user_data.c */; };
+		4F00B1E7AA2E14D15D6EB6FD9E2D5E435FB6EFBC23187311 /* call_calls_foreign.c in Sources */ = {isa = PBXBuildFile; fileRef = 4B3C826893074179E867DC6FD71B12AB847241FECAEC97B9 /* call_calls_foreign.c */; };
+		57ACF33531D07E2230F331322B367F94BD3970871ED1DC62 /* test.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BCF060B7B2F762A703CED121E7AFF5CC6CD69C3394BCC6A /* test.c */; };
+		7EA03DFDDA534BB5E0A3E060CB4AB9A795DD42D4374E39F5 /* call_wren_call_root.c in Sources */ = {isa = PBXBuildFile; fileRef = 76528755F9C7671DBBC803E92144CCFD3F68559C05B4D5D /* call_wren_call_root.c */; };
+		81BA759F29C70EE395343C60850862557A6AEBAD5862AD23 /* new_vm.c in Sources */ = {isa = PBXBuildFile; fileRef = 4EBD9A54C22EBF6B64D7010ED9415A9D69173185C95D55AB /* new_vm.c */; };
+		9D701AA72472A7E9BCA6A28F7FBDF81BB5558F326DEFDE29 /* libwren.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0F1FB8E5C06B0D116CD90176DBDF0C315CEB0AFE32BDF11 /* libwren.a */; };
+		9E2B0FE04CFB0BD75779BB9ABE1DACC9F68F1A7173E45A17 /* raw_value.c in Sources */ = {isa = PBXBuildFile; fileRef = A981556E65D1621FD74F73608E0C1AD1BA7EA72D75A7A85F /* raw_value.c */; };
+		B71BEE8ABD0CC4E1BD23737E81C21B53CBAFF47F3630C321 /* reset_stack_after_call_abort.c in Sources */ = {isa = PBXBuildFile; fileRef = 22E5C24CB1B12E892433E7F7FA506CBB3591B9F1D7C24C9 /* reset_stack_after_call_abort.c */; };
+		BCBC5048A9B950DFA44E2C7FD94B1FD1ED63D9E9B4585F1F /* error.c in Sources */ = {isa = PBXBuildFile; fileRef = 33791632F961FEA7F16FB4F89C5025596A81658F2B7604E7 /* error.c */; };
+		C404D1E447E53E8332034EEB9E72A8F5EB52507D76EBBCC3 /* call.c in Sources */ = {isa = PBXBuildFile; fileRef = 2DC880A02F776B0B54A059732E83D3DF43D5807B454E14B /* call.c */; };
+		E0F940614D8AE463F4730722A8CC37D5D9A9B66F7C2682A3 /* handle.c in Sources */ = {isa = PBXBuildFile; fileRef = 8097C5CB069BFCEB96B12C851DAE981D9AF15CFC0DCA932B /* handle.c */; };
+		E9E1B8958F510F77B717750FA173C5693472A4D77A74FDB7 /* reset_stack_after_foreign_construct.c in Sources */ = {isa = PBXBuildFile; fileRef = B021F74A310165BFB41C6637D4689371A54669E7EB9E4BFF /* reset_stack_after_foreign_construct.c */; };
+		FA3732EB1C549169E1C90F224BE6605B2ADEBC8C26F39FA9 /* lists.c in Sources */ = {isa = PBXBuildFile; fileRef = 62AC93F41058591C4216804E3F3AC433D33189B73198BD1 /* lists.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		A06CA0BEC692D0702D99C6FE /* PBXContainerItemProxy */ = {
+		68838BB0A06CA0BE6A91894CC692D0707F9FB3402D99C6FE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = DA66CE78FC327BAA38E7A4B8 /* wren.xcodeproj */;
+			containerPortal = 7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* wren.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 49DA870B4D4B593DCEB7FD4B;
+			remoteGlobalIDString = C97D98CA49DA870BA0FF1DC14D4B593D8FF27031CEB7FD4B;
 			remoteInfo = libwren.a;
 		};
-		F2A7135718CD43097FD43997 /* PBXContainerItemProxy */ = {
+		6AF5CCE6F2A713576D03CA8318CD43098211F4767FD43997 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = DA66CE78FC327BAA38E7A4B8 /* wren.xcodeproj */;
+			containerPortal = 7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* wren.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = FC9829912B3E7D83847FD7D1;
+			remoteGlobalIDString = 442B2B3DFC9829911C27560F2B3E7D83ED176FD4847FD7D1;
 			remoteInfo = libwren.a;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		069BFCEB1DAE981D0DCA932B /* handle.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = handle.c; path = ../../test/api/handle.c; sourceTree = "<group>"; };
-		0A1D5C440D8E2E768EFAD284 /* wren_test */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = wren_test; path = wren_test; sourceTree = BUILT_PRODUCTS_DIR; };
-		1270B31D5FD3A94FD5F2A95D /* get_variable.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = get_variable.c; path = ../../test/api/get_variable.c; sourceTree = "<group>"; };
-		13133647AB601BF9D9A71C87 /* call_wren_call_root.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call_wren_call_root.h; path = ../../test/api/call_wren_call_root.h; sourceTree = "<group>"; };
-		17B63BDB49AF868DC38EC21B /* foreign_class.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = foreign_class.h; path = ../../test/api/foreign_class.h; sourceTree = "<group>"; };
-		21B810EB49F2C99D318E572B /* api_tests.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = api_tests.c; path = ../../test/api/api_tests.c; sourceTree = "<group>"; };
-		2CA1DDD554DC96873C782415 /* api_tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = api_tests.h; path = ../../test/api/api_tests.h; sourceTree = "<group>"; };
-		2F776B0B32E83D3DB454E14B /* call.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = call.c; path = ../../test/api/call.c; sourceTree = "<group>"; };
-		3070CF87D35EF6396284D5C7 /* slots.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = slots.h; path = ../../test/api/slots.h; sourceTree = "<group>"; };
-		30E3DEE9D44B0C9BEB80C529 /* reset_stack_after_foreign_construct.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = reset_stack_after_foreign_construct.h; path = ../../test/api/reset_stack_after_foreign_construct.h; sourceTree = "<group>"; };
-		310165BFD4689371EB9E4BFF /* reset_stack_after_foreign_construct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = reset_stack_after_foreign_construct.c; path = ../../test/api/reset_stack_after_foreign_construct.c; sourceTree = "<group>"; };
-		33526D1DD64093CF6566735D /* slots.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = slots.c; path = ../../test/api/slots.c; sourceTree = "<group>"; };
-		3AEABBF53E5B8E27BFC83235 /* maps.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = maps.c; path = ../../test/api/maps.c; sourceTree = "<group>"; };
-		3E23E7FBE1120EAD7037EE3B /* lists.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = lists.h; path = ../../test/api/lists.h; sourceTree = "<group>"; };
-		41058591E3F3AC4373198BD1 /* lists.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = lists.c; path = ../../test/api/lists.c; sourceTree = "<group>"; };
-		50338489786E3D3B6009CAC9 /* benchmark.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = benchmark.c; path = ../../test/api/benchmark.c; sourceTree = "<group>"; };
-		535262BB751E0FEDB1D338FB /* resolution.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = resolution.c; path = ../../test/api/resolution.c; sourceTree = "<group>"; };
-		57CA1E756EDCB9A75EF8B4B5 /* new_vm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = new_vm.h; path = ../../test/api/new_vm.h; sourceTree = "<group>"; };
-		5B1D517383580A256AF397B3 /* benchmark.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = benchmark.h; path = ../../test/api/benchmark.h; sourceTree = "<group>"; };
-		6E0F7DF4115B07262C2BD434 /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = main.c; path = ../../test/main.c; sourceTree = "<group>"; };
-		7428A1E7C18B981937AA9827 /* get_variable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = get_variable.h; path = ../../test/api/get_variable.h; sourceTree = "<group>"; };
-		7B2F762A1E7AFF5C394BCC6A /* test.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = test.c; path = ../../test/test.c; sourceTree = "<group>"; };
-		7C8B0753C52A4585E855FD93 /* reset_stack_after_call_abort.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = reset_stack_after_call_abort.h; path = ../../test/api/reset_stack_after_call_abort.h; sourceTree = "<group>"; };
-		8A4FC471BC490F2336284AB1 /* foreign_class.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = foreign_class.c; path = ../../test/api/foreign_class.c; sourceTree = "<group>"; };
-		93074179D71B12ABCAEC97B9 /* call_calls_foreign.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = call_calls_foreign.c; path = ../../test/api/call_calls_foreign.c; sourceTree = "<group>"; };
-		9C375BF5B349F727A365F235 /* handle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = handle.h; path = ../../test/api/handle.h; sourceTree = "<group>"; };
-		A415E4D5A786B70728F35B15 /* call.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call.h; path = ../../test/api/call.h; sourceTree = "<group>"; };
-		ABEF15744F3A9EA66A0B6BB4 /* test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = test.h; path = ../../test/test.h; sourceTree = "<group>"; };
-		AF8935BFB2FA07F13466ABFF /* maps.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = maps.h; path = ../../test/api/maps.h; sourceTree = "<group>"; };
-		B0175F83D8521835BFEDA5C3 /* user_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = user_data.c; path = ../../test/api/user_data.c; sourceTree = "<group>"; };
-		B0267C45D1F229770EA75285 /* resolution.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = resolution.h; path = ../../test/api/resolution.h; sourceTree = "<group>"; };
-		B1B12E89FA506CBB1D7C24C9 /* reset_stack_after_call_abort.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = reset_stack_after_call_abort.c; path = ../../test/api/reset_stack_after_call_abort.c; sourceTree = "<group>"; };
-		BB012C6DE33BE51FCAD772AD /* user_data.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = user_data.h; path = ../../test/api/user_data.h; sourceTree = "<group>"; };
-		C22EBF6BD9415A9DC95D55AB /* new_vm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = new_vm.c; path = ../../test/api/new_vm.c; sourceTree = "<group>"; };
-		DA66CE78FC327BAA38E7A4B8 /* libwren.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "wren.xcodeproj"; path = wren.xcodeproj; sourceTree = SOURCE_ROOT; };
-		E97890032D8C6135215DE643 /* call_calls_foreign.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call_calls_foreign.h; path = ../../test/api/call_calls_foreign.h; sourceTree = "<group>"; };
-		F6806111996E87C328946751 /* error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = error.h; path = ../../test/api/error.h; sourceTree = "<group>"; };
-		F961FEA79C5025592B7604E7 /* error.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = error.c; path = ../../test/api/error.c; sourceTree = "<group>"; };
-		F9C7671D92144CCFC05B4D5D /* call_wren_call_root.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = call_wren_call_root.c; path = ../../test/api/call_wren_call_root.c; sourceTree = "<group>"; };
+		12758C4F21B810EB4043AA4149F2C99D2372DE0E318E572B /* api_tests.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = api_tests.c; path = ../../test/api/api_tests.c; sourceTree = "<group>"; };
+		1C11B4B70BB2F092F8F393D98F5E7BB12BE6D0A80917549 /* raw_value.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = raw_value.h; path = ../../test/api/raw_value.h; sourceTree = "<group>"; };
+		22E5C24CB1B12E892433E7F7FA506CBB3591B9F1D7C24C9 /* reset_stack_after_call_abort.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = reset_stack_after_call_abort.c; path = ../../test/api/reset_stack_after_call_abort.c; sourceTree = "<group>"; };
+		23A6011D33526D1DE19C9FE2D64093CF5AAE50796566735D /* slots.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = slots.c; path = ../../test/api/slots.c; sourceTree = "<group>"; };
+		29C2F880B0267C453905B9DD1F229776F5BB6430EA75285 /* resolution.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = resolution.h; path = ../../test/api/resolution.h; sourceTree = "<group>"; };
+		2DC880A02F776B0B54A059732E83D3DF43D5807B454E14B /* call.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = call.c; path = ../../test/api/call.c; sourceTree = "<group>"; };
+		30A9047A57CA1E7546C26B346EDCB9A74B029BAB5EF8B4B5 /* new_vm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = new_vm.h; path = ../../test/api/new_vm.h; sourceTree = "<group>"; };
+		33791632F961FEA7F16FB4F89C5025596A81658F2B7604E7 /* error.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = error.c; path = ../../test/api/error.c; sourceTree = "<group>"; };
+		3733EC4F8A4FC471FEC1F183BC490F237FB3136B36284AB1 /* foreign_class.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = foreign_class.c; path = ../../test/api/foreign_class.c; sourceTree = "<group>"; };
+		4B3C826893074179E867DC6FD71B12AB847241FECAEC97B9 /* call_calls_foreign.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = call_calls_foreign.c; path = ../../test/api/call_calls_foreign.c; sourceTree = "<group>"; };
+		4B9DDA620A1D5C44231F5F590D8E2E761212B1C98EFAD284 /* wren_test */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = wren_test; path = wren_test; sourceTree = BUILT_PRODUCTS_DIR; };
+		4EBD9A54C22EBF6B64D7010ED9415A9D69173185C95D55AB /* new_vm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = new_vm.c; path = ../../test/api/new_vm.c; sourceTree = "<group>"; };
+		5A0892B77428A1E753DE9FE2C18B981915750F9437AA9827 /* get_variable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = get_variable.h; path = ../../test/api/get_variable.h; sourceTree = "<group>"; };
+		5BCF060B7B2F762A703CED121E7AFF5CC6CD69C3394BCC6A /* test.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = test.c; path = ../../test/test.c; sourceTree = "<group>"; };
+		5D13AB4B13133647F27DA433AB601BF9BAB7A94ED9A71C87 /* call_wren_call_root.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call_wren_call_root.h; path = ../../test/api/call_wren_call_root.h; sourceTree = "<group>"; };
+		5DEAE3937C8B07535F39093EC52A45853E5E3CE5E855FD93 /* reset_stack_after_call_abort.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = reset_stack_after_call_abort.h; path = ../../test/api/reset_stack_after_call_abort.h; sourceTree = "<group>"; };
+		62832FF09C375BF5789C96AAB349F7277CDCC721A365F235 /* handle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = handle.h; path = ../../test/api/handle.h; sourceTree = "<group>"; };
+		62AC93F41058591C4216804E3F3AC433D33189B73198BD1 /* lists.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = lists.c; path = ../../test/api/lists.c; sourceTree = "<group>"; };
+		63BED14F50338489918CEF41786E3D3B74BC230E6009CAC9 /* benchmark.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = benchmark.c; path = ../../test/api/benchmark.c; sourceTree = "<group>"; };
+		6AB5522C2CA1DDD59883701E54DC96877BB2A3EB3C782415 /* api_tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = api_tests.h; path = ../../test/api/api_tests.h; sourceTree = "<group>"; };
+		6F860494B0175F839D542286D852183580835653BFEDA5C3 /* user_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = user_data.c; path = ../../test/api/user_data.c; sourceTree = "<group>"; };
+		76528755F9C7671DBBC803E92144CCFD3F68559C05B4D5D /* call_wren_call_root.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = call_wren_call_root.c; path = ../../test/api/call_wren_call_root.c; sourceTree = "<group>"; };
+		799E86A53E23E7FB3795256AE1120EADB0A6D6017037EE3B /* lists.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = lists.h; path = ../../test/api/lists.h; sourceTree = "<group>"; };
+		7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* libwren.a */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "wren.xcodeproj"; path = wren.xcodeproj; sourceTree = SOURCE_ROOT; };
+		8097C5CB069BFCEB96B12C851DAE981D9AF15CFC0DCA932B /* handle.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = handle.c; path = ../../test/api/handle.c; sourceTree = "<group>"; };
+		83AB881F6E0F7DF498196F26115B0726EEA9EBD72C2BD434 /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = main.c; path = ../../test/main.c; sourceTree = "<group>"; };
+		936E17C317B63BDB5AFC1CF749AF868DDBED3EDEC38EC21B /* foreign_class.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = foreign_class.h; path = ../../test/api/foreign_class.h; sourceTree = "<group>"; };
+		9719BE833070CF8755105D48D35EF639CE220DDF6284D5C7 /* slots.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = slots.h; path = ../../test/api/slots.h; sourceTree = "<group>"; };
+		9A9B8301270B31D37FC55B5FD3A94FC516350CD5F2A95D /* get_variable.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = get_variable.c; path = ../../test/api/get_variable.c; sourceTree = "<group>"; };
+		A353FBDF30E3DEE9A74E6ACCD44B0C9B98786E7CEB80C529 /* reset_stack_after_foreign_construct.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = reset_stack_after_foreign_construct.h; path = ../../test/api/reset_stack_after_foreign_construct.h; sourceTree = "<group>"; };
+		A6ECD398F680611164E3725E996E87C3DDF522F528946751 /* error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = error.h; path = ../../test/api/error.h; sourceTree = "<group>"; };
+		A7E6F17A415E4D5E1FFF40EA786B707D0F3467F28F35B15 /* call.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call.h; path = ../../test/api/call.h; sourceTree = "<group>"; };
+		A981556E65D1621FD74F73608E0C1AD1BA7EA72D75A7A85F /* raw_value.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = raw_value.c; path = ../../test/api/raw_value.c; sourceTree = "<group>"; };
+		A9F68E5FAF8935BF81781356B2FA07F1706B65C73466ABFF /* maps.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = maps.h; path = ../../test/api/maps.h; sourceTree = "<group>"; };
+		AD231444ABEF1574C190FB4B4F3A9EA6182177FC6A0B6BB4 /* test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = test.h; path = ../../test/test.h; sourceTree = "<group>"; };
+		B021F74A310165BFB41C6637D4689371A54669E7EB9E4BFF /* reset_stack_after_foreign_construct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = reset_stack_after_foreign_construct.c; path = ../../test/api/reset_stack_after_foreign_construct.c; sourceTree = "<group>"; };
+		B713D112E9789003543F2B1A2D8C6135F04990A9215DE643 /* call_calls_foreign.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call_calls_foreign.h; path = ../../test/api/call_calls_foreign.h; sourceTree = "<group>"; };
+		BBFE972C5B1D5173E9CCB51E83580A25CCFBE8EB6AF397B3 /* benchmark.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = benchmark.h; path = ../../test/api/benchmark.h; sourceTree = "<group>"; };
+		C7C5CA71BB012C6DF593E863E33BE51FD8C31C30CAD772AD /* user_data.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = user_data.h; path = ../../test/api/user_data.h; sourceTree = "<group>"; };
+		C98A7702535262BBA357DA1F751E0FEDF2334C4B1D338FB /* resolution.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = resolution.c; path = ../../test/api/resolution.c; sourceTree = "<group>"; };
+		CD409FE83AEABBF5A4C224DF3E5B8E2793B5774FBFC83235 /* maps.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = maps.c; path = ../../test/api/maps.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		1823CFB4BB6F58E6D64025F4 /* Frameworks */ = {
+		FC377FF81823CFB410A566FEBB6F58E66735E3AFD64025F4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F97FE7C03DCE8D327FF5C600 /* libwren.a in Frameworks */,
+				9D701AA72472A7E9BCA6A28F7FBDF81BB5558F326DEFDE29 /* libwren.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		216C0E3E1AD20FB00E6D6C7E /* Products */ = {
+		2AAD7708BA74099BD6FFEA633DB9670D839A24DD6700E7DB /* wren_test */ = {
 			isa = PBXGroup;
 			children = (
-				F5D0B9A8179C66DA54518FE8 /* libwren.a */,
+				AEF2CAC24611E03CE593A96D3202EBEE2575332C843A867C /* api */,
+				83AB881F6E0F7DF498196F26115B0726EEA9EBD72C2BD434 /* main.c */,
+				5BCF060B7B2F762A703CED121E7AFF5CC6CD69C3394BCC6A /* test.c */,
+				AD231444ABEF1574C190FB4B4F3A9EA6182177FC6A0B6BB4 /* test.h */,
+				DE2FD571A6C936B48E134D4D9B3FADE6BA17F9BDEA134CF4 /* Products */,
+				DE2FDC7F9D968EAA8E13545B920D05DCBA1800CBE0E0A4EA /* Projects */,
+			);
+			name = wren_test;
+			sourceTree = "<group>";
+		};
+		6FC5ECF3216C0E3E490C2AF01AD20FB0D5526A450E6D6C7E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D0F1FB8E5C06B0D116CD90176DBDF0C315CEB0AFE32BDF11 /* libwren.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		4611E03C3202EBEE843A867C /* api */ = {
+		AEF2CAC24611E03CE593A96D3202EBEE2575332C843A867C /* api */ = {
 			isa = PBXGroup;
 			children = (
-				21B810EB49F2C99D318E572B /* api_tests.c */,
-				2CA1DDD554DC96873C782415 /* api_tests.h */,
-				50338489786E3D3B6009CAC9 /* benchmark.c */,
-				5B1D517383580A256AF397B3 /* benchmark.h */,
-				2F776B0B32E83D3DB454E14B /* call.c */,
-				A415E4D5A786B70728F35B15 /* call.h */,
-				93074179D71B12ABCAEC97B9 /* call_calls_foreign.c */,
-				E97890032D8C6135215DE643 /* call_calls_foreign.h */,
-				F9C7671D92144CCFC05B4D5D /* call_wren_call_root.c */,
-				13133647AB601BF9D9A71C87 /* call_wren_call_root.h */,
-				F961FEA79C5025592B7604E7 /* error.c */,
-				F6806111996E87C328946751 /* error.h */,
-				8A4FC471BC490F2336284AB1 /* foreign_class.c */,
-				17B63BDB49AF868DC38EC21B /* foreign_class.h */,
-				1270B31D5FD3A94FD5F2A95D /* get_variable.c */,
-				7428A1E7C18B981937AA9827 /* get_variable.h */,
-				069BFCEB1DAE981D0DCA932B /* handle.c */,
-				9C375BF5B349F727A365F235 /* handle.h */,
-				41058591E3F3AC4373198BD1 /* lists.c */,
-				3E23E7FBE1120EAD7037EE3B /* lists.h */,
-				3AEABBF53E5B8E27BFC83235 /* maps.c */,
-				AF8935BFB2FA07F13466ABFF /* maps.h */,
-				C22EBF6BD9415A9DC95D55AB /* new_vm.c */,
-				57CA1E756EDCB9A75EF8B4B5 /* new_vm.h */,
-				B1B12E89FA506CBB1D7C24C9 /* reset_stack_after_call_abort.c */,
-				7C8B0753C52A4585E855FD93 /* reset_stack_after_call_abort.h */,
-				310165BFD4689371EB9E4BFF /* reset_stack_after_foreign_construct.c */,
-				30E3DEE9D44B0C9BEB80C529 /* reset_stack_after_foreign_construct.h */,
-				535262BB751E0FEDB1D338FB /* resolution.c */,
-				B0267C45D1F229770EA75285 /* resolution.h */,
-				33526D1DD64093CF6566735D /* slots.c */,
-				3070CF87D35EF6396284D5C7 /* slots.h */,
-				B0175F83D8521835BFEDA5C3 /* user_data.c */,
-				BB012C6DE33BE51FCAD772AD /* user_data.h */,
+				12758C4F21B810EB4043AA4149F2C99D2372DE0E318E572B /* api_tests.c */,
+				6AB5522C2CA1DDD59883701E54DC96877BB2A3EB3C782415 /* api_tests.h */,
+				63BED14F50338489918CEF41786E3D3B74BC230E6009CAC9 /* benchmark.c */,
+				BBFE972C5B1D5173E9CCB51E83580A25CCFBE8EB6AF397B3 /* benchmark.h */,
+				2DC880A02F776B0B54A059732E83D3DF43D5807B454E14B /* call.c */,
+				A7E6F17A415E4D5E1FFF40EA786B707D0F3467F28F35B15 /* call.h */,
+				4B3C826893074179E867DC6FD71B12AB847241FECAEC97B9 /* call_calls_foreign.c */,
+				B713D112E9789003543F2B1A2D8C6135F04990A9215DE643 /* call_calls_foreign.h */,
+				76528755F9C7671DBBC803E92144CCFD3F68559C05B4D5D /* call_wren_call_root.c */,
+				5D13AB4B13133647F27DA433AB601BF9BAB7A94ED9A71C87 /* call_wren_call_root.h */,
+				33791632F961FEA7F16FB4F89C5025596A81658F2B7604E7 /* error.c */,
+				A6ECD398F680611164E3725E996E87C3DDF522F528946751 /* error.h */,
+				3733EC4F8A4FC471FEC1F183BC490F237FB3136B36284AB1 /* foreign_class.c */,
+				936E17C317B63BDB5AFC1CF749AF868DDBED3EDEC38EC21B /* foreign_class.h */,
+				9A9B8301270B31D37FC55B5FD3A94FC516350CD5F2A95D /* get_variable.c */,
+				5A0892B77428A1E753DE9FE2C18B981915750F9437AA9827 /* get_variable.h */,
+				8097C5CB069BFCEB96B12C851DAE981D9AF15CFC0DCA932B /* handle.c */,
+				62832FF09C375BF5789C96AAB349F7277CDCC721A365F235 /* handle.h */,
+				62AC93F41058591C4216804E3F3AC433D33189B73198BD1 /* lists.c */,
+				799E86A53E23E7FB3795256AE1120EADB0A6D6017037EE3B /* lists.h */,
+				CD409FE83AEABBF5A4C224DF3E5B8E2793B5774FBFC83235 /* maps.c */,
+				A9F68E5FAF8935BF81781356B2FA07F1706B65C73466ABFF /* maps.h */,
+				4EBD9A54C22EBF6B64D7010ED9415A9D69173185C95D55AB /* new_vm.c */,
+				30A9047A57CA1E7546C26B346EDCB9A74B029BAB5EF8B4B5 /* new_vm.h */,
+				A981556E65D1621FD74F73608E0C1AD1BA7EA72D75A7A85F /* raw_value.c */,
+				1C11B4B70BB2F092F8F393D98F5E7BB12BE6D0A80917549 /* raw_value.h */,
+				22E5C24CB1B12E892433E7F7FA506CBB3591B9F1D7C24C9 /* reset_stack_after_call_abort.c */,
+				5DEAE3937C8B07535F39093EC52A45853E5E3CE5E855FD93 /* reset_stack_after_call_abort.h */,
+				B021F74A310165BFB41C6637D4689371A54669E7EB9E4BFF /* reset_stack_after_foreign_construct.c */,
+				A353FBDF30E3DEE9A74E6ACCD44B0C9B98786E7CEB80C529 /* reset_stack_after_foreign_construct.h */,
+				C98A7702535262BBA357DA1F751E0FEDF2334C4B1D338FB /* resolution.c */,
+				29C2F880B0267C453905B9DD1F229776F5BB6430EA75285 /* resolution.h */,
+				23A6011D33526D1DE19C9FE2D64093CF5AAE50796566735D /* slots.c */,
+				9719BE833070CF8755105D48D35EF639CE220DDF6284D5C7 /* slots.h */,
+				6F860494B0175F839D542286D852183580835653BFEDA5C3 /* user_data.c */,
+				C7C5CA71BB012C6DF593E863E33BE51FD8C31C30CAD772AD /* user_data.h */,
 			);
 			name = api;
 			sourceTree = "<group>";
 		};
-		9D968EAA920D05DCE0E0A4EA /* Projects */ = {
+		DE2FD571A6C936B48E134D4D9B3FADE6BA17F9BDEA134CF4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DA66CE78FC327BAA38E7A4B8 /* wren.xcodeproj */,
-				DA66CE78FC327BAA38E7A4B8 /* wren.xcodeproj */,
-			);
-			name = Projects;
-			sourceTree = "<group>";
-		};
-		A6C936B49B3FADE6EA134CF4 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				0A1D5C440D8E2E768EFAD284 /* wren_test */,
+				4B9DDA620A1D5C44231F5F590D8E2E761212B1C98EFAD284 /* wren_test */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		BA74099B3DB9670D6700E7DB /* wren_test */ = {
+		DE2FDC7F9D968EAA8E13545B920D05DCBA1800CBE0E0A4EA /* Projects */ = {
 			isa = PBXGroup;
 			children = (
-				4611E03C3202EBEE843A867C /* api */,
-				6E0F7DF4115B07262C2BD434 /* main.c */,
-				7B2F762A1E7AFF5C394BCC6A /* test.c */,
-				ABEF15744F3A9EA66A0B6BB4 /* test.h */,
-				A6C936B49B3FADE6EA134CF4 /* Products */,
-				9D968EAA920D05DCE0E0A4EA /* Projects */,
+				7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* wren.xcodeproj */,
+				7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* wren.xcodeproj */,
 			);
-			name = wren_test;
+			name = Projects;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		76C8BBAAA56F0F9CFEB069EA /* wren_test */ = {
+		EB055BC676C8BBAAC3018697A56F0F9C93F1A05CFEB069EA /* wren_test */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 065F1813A9AAA145C47B6E53 /* Build configuration list for PBXNativeTarget "wren_test" */;
+			buildConfigurationList = FC377FF7065F181310A566FDA9AAA1456735E3AEC47B6E53 /* Build configuration list for PBXNativeTarget "wren_test" */;
 			buildPhases = (
-				880B50542B56D9864627A694 /* Resources */,
-				F1B869AB9503F2DDAFD4BFEB /* Sources */,
-				1823CFB4BB6F58E6D64025F4 /* Frameworks */,
+				FC377FFB880B505410A567022B56D9866735E3B34627A694 /* Resources */,
+				FC377FFBF1B869AB10A567029503F2DD6735E3B3AFD4BFEB /* Sources */,
+				FC377FF81823CFB410A566FEBB6F58E66735E3AFD64025F4 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				0F244B47088A4CB9FC25A987 /* PBXTargetDependency */,
-				0F244B47088A4CB9FC25A987 /* PBXTargetDependency */,
+				6FD8E72A0F244B47491F2527088A4CB9D565647BFC25A987 /* PBXTargetDependency */,
+				6FD8E72A0F244B47491F2527088A4CB9D565647BFC25A987 /* PBXTargetDependency */,
 			);
 			name = wren_test;
 			productInstallPath = "$(HOME)/bin";
 			productName = wren_test;
-			productReference = 0A1D5C440D8E2E768EFAD284 /* wren_test */;
+			productReference = 4B9DDA620A1D5C44231F5F590D8E2E761212B1C98EFAD284 /* wren_test */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -210,37 +215,37 @@
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren_test" */;
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 1;
-			mainGroup = BA74099B3DB9670D6700E7DB /* wren_test */;
+			mainGroup = 2AAD7708BA74099BD6FFEA633DB9670D839A24DD6700E7DB /* wren_test */;
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 216C0E3E1AD20FB00E6D6C7E /* Products */;
-					ProjectRef = DA66CE78FC327BAA38E7A4B8 /* wren.xcodeproj */;
+					ProductGroup = 6FC5ECF3216C0E3E490C2AF01AD20FB0D5526A450E6D6C7E /* Products */;
+					ProjectRef = 7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* wren.xcodeproj */;
 				},
 				{
-					ProductGroup = 216C0E3E1AD20FB00E6D6C7E /* Products */;
-					ProjectRef = DA66CE78FC327BAA38E7A4B8 /* wren.xcodeproj */;
+					ProductGroup = 6FC5ECF3216C0E3E490C2AF01AD20FB0D5526A450E6D6C7E /* Products */;
+					ProjectRef = 7BABDE6473523AB2E0D662C4AA565E49872109EC412D0F2 /* wren.xcodeproj */;
 				},
 			);
 			projectRoot = "";
 			targets = (
-				76C8BBAAA56F0F9CFEB069EA /* wren_test */,
+				EB055BC676C8BBAAC3018697A56F0F9C93F1A05CFEB069EA /* wren_test */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		F5D0B9A8179C66DA54518FE8 /* libwren.a */ = {
+		D0F1FB8E5C06B0D116CD90176DBDF0C315CEB0AFE32BDF11 /* libwren.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libwren.a;
-			remoteRef = A06CA0BEC692D0702D99C6FE /* PBXContainerItemProxy */;
+			remoteRef = 68838BB0A06CA0BE6A91894CC692D0707F9FB3402D99C6FE /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
-		880B50542B56D9864627A694 /* Resources */ = {
+		FC377FFB880B505410A567022B56D9866735E3B34627A694 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -250,39 +255,40 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		F1B869AB9503F2DDAFD4BFEB /* Sources */ = {
+		FC377FFBF1B869AB10A567029503F2DD6735E3B3AFD4BFEB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7CCD7163EDF01255A3B6BFA3 /* api_tests.c in Sources */,
-				D43547E14557E8D3FB1E9621 /* benchmark.c in Sources */,
-				47E53E839E72A8F576EBBCC3 /* call.c in Sources */,
-				AA2E14D19E2D5E4323187311 /* call_calls_foreign.c in Sources */,
-				DA534BB5CB4AB9A7374E39F5 /* call_wren_call_root.c in Sources */,
-				A9B950DFD94B1FD1B4585F1F /* error.c in Sources */,
-				181D16496F82893B2190A489 /* foreign_class.c in Sources */,
-				E21864B54F40732750D362F5 /* get_variable.c in Sources */,
-				4D8AE463A8CC37D57C2682A3 /* handle.c in Sources */,
-				1C5491694BE6605B26F39FA9 /* lists.c in Sources */,
-				4EA04F0DA52DB97F7DA6CD4D /* maps.c in Sources */,
-				29C70EE3850862555862AD23 /* new_vm.c in Sources */,
-				BD0CC4E181C21B533630C321 /* reset_stack_after_call_abort.c in Sources */,
-				8F510F77A173C5697A74FDB7 /* reset_stack_after_foreign_construct.c in Sources */,
-				59615B339DB000A5DFD73973 /* resolution.c in Sources */,
-				134AABB542DC7AA71DE9B9F5 /* slots.c in Sources */,
-				DAAEBD7B4BD15E6D01980BBB /* user_data.c in Sources */,
-				78667B8C71CC7CFE6567D9CC /* main.c in Sources */,
-				31D07E222B367F941ED1DC62 /* test.c in Sources */,
+				3E2E0CA87CCD7163F77CB862EDF0125596921739A3B6BFA3 /* api_tests.c in Sources */,
+				2891C992D43547E1E1E0754D4557E8D380F5D423FB1E9621 /* benchmark.c in Sources */,
+				C404D1E447E53E8332034EEB9E72A8F5EB52507D76EBBCC3 /* call.c in Sources */,
+				4F00B1E7AA2E14D15D6EB6FD9E2D5E435FB6EFBC23187311 /* call_calls_foreign.c in Sources */,
+				7EA03DFDDA534BB5E0A3E060CB4AB9A795DD42D4374E39F5 /* call_wren_call_root.c in Sources */,
+				BCBC5048A9B950DFA44E2C7FD94B1FD1ED63D9E9B4585F1F /* error.c in Sources */,
+				42DA56B1181D1649E2C4612D6F82893B5BDBF7A62190A489 /* foreign_class.c in Sources */,
+				47D2884EE21864B57A0A75FB4F407327C705C7ED50D362F5 /* get_variable.c in Sources */,
+				E0F940614D8AE463F4730722A8CC37D5D9A9B66F7C2682A3 /* handle.c in Sources */,
+				FA3732EB1C549169E1C90F224BE6605B2ADEBC8C26F39FA9 /* lists.c in Sources */,
+				11FA61CA4EA04F0D7FF8DED1A52DB97F3947E0637DA6CD4D /* maps.c in Sources */,
+				81BA759F29C70EE395343C60850862557A6AEBAD5862AD23 /* new_vm.c in Sources */,
+				9E2B0FE04CFB0BD75779BB9ABE1DACC9F68F1A7173E45A17 /* raw_value.c in Sources */,
+				B71BEE8ABD0CC4E1BD23737E81C21B53CBAFF47F3630C321 /* reset_stack_after_call_abort.c in Sources */,
+				E9E1B8958F510F77B717750FA173C5693472A4D77A74FDB7 /* reset_stack_after_foreign_construct.c in Sources */,
+				37617F4259615B337F0A035D9DB000A538F272B8DFD73973 /* resolution.c in Sources */,
+				39CD4A40134AABB5215F267742DC7AA76A74D3E11DE9B9F5 /* slots.c in Sources */,
+				4D524052DAAEBD7B6A0EC0D4BD15E6DA5B64AE401980BBB /* user_data.c in Sources */,
+				4C4F423378667B8C2595803071CC7CFEB1DBBF856567D9CC /* main.c in Sources */,
+				57ACF33531D07E2230F331322B367F94BD3970871ED1DC62 /* test.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0F244B47088A4CB9FC25A987 /* PBXTargetDependency */ = {
+		6FD8E72A0F244B47491F2527088A4CB9D565647BFC25A987 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = libwren.a;
-			targetProxy = F2A7135718CD43097FD43997 /* PBXContainerItemProxy */;
+			targetProxy = 6AF5CCE6F2A713576D03CA8318CD43098211F4767FD43997 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -290,13 +296,48 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		4591788AE9E4163CFC1C5ECA /* Debug */ = {
+		4AF874EDE4399D442279F9E4E7AA6F76116D4C5569171384 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = C99;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					"WREN_NAN_TAGGING=0",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OBJROOT = "obj/64bit-no-nan-tagging/Release/wren_test";
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = ../../bin;
+				USER_HEADER_SEARCH_PATHS = (
+					../../src/include,
+				);
+			};
+			name = Release;
+		};
+		E764569CA115B6931532748EC9506F45F861A85BB0EBFCD3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CONFIGURATION_BUILD_DIR = ../../bin;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_DYNAMIC_NO_PIC = NO;
+				INSTALL_PATH = /usr/local/bin;
+				PRODUCT_NAME = wren_test;
+			};
+			name = Release;
+		};
+		E81732204591788ACF9AF55CE9E4163CC3D62BFFC1C5ECA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
 				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
 				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_C_LANGUAGE_STANDARD = C99;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -315,19 +356,7 @@
 			};
 			name = Debug;
 		};
-		A115B693C9506F45B0EBFCD3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CONFIGURATION_BUILD_DIR = ../../bin;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_DYNAMIC_NO_PIC = NO;
-				INSTALL_PATH = /usr/local/bin;
-				PRODUCT_NAME = wren_test;
-			};
-			name = Release;
-		};
-		A194E159EA05C58B2EA49799 /* Debug */ = {
+		F55DF4FCA194E159B2E1CA3AEA05C58B44223EA42EA49799 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -339,54 +368,31 @@
 			};
 			name = Debug;
 		};
-		E4399D44E7AA6F7669171384 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
-				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
-				GCC_C_LANGUAGE_STANDARD = c99;
-				GCC_OPTIMIZATION_LEVEL = 3;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					NDEBUG,
-					"WREN_NAN_TAGGING=0",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = "obj/64bit-no-nan-tagging/Release/wren_test";
-				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = ../../bin;
-				USER_HEADER_SEARCH_PATHS = (
-					../../src/include,
-				);
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		065F1813A9AAA145C47B6E53 /* Build configuration list for PBXNativeTarget "wren_test" */ = {
+		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren_test" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A115B693C9506F45B0EBFCD3 /* Release */,
-				A115B693C9506F45B0EBFCD3 /* Release */,
-				A115B693C9506F45B0EBFCD3 /* Release */,
-				A194E159EA05C58B2EA49799 /* Debug */,
-				A194E159EA05C58B2EA49799 /* Debug */,
-				A194E159EA05C58B2EA49799 /* Debug */,
+				4AF874EDE4399D442279F9E4E7AA6F76116D4C5569171384 /* Release */,
+				4AF874EDE4399D442279F9E4E7AA6F76116D4C5569171384 /* Release */,
+				4AF874EDE4399D442279F9E4E7AA6F76116D4C5569171384 /* Release */,
+				E81732204591788ACF9AF55CE9E4163CC3D62BFFC1C5ECA /* Debug */,
+				E81732204591788ACF9AF55CE9E4163CC3D62BFFC1C5ECA /* Debug */,
+				E81732204591788ACF9AF55CE9E4163CC3D62BFFC1C5ECA /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "wren_test" */ = {
+		FC377FF7065F181310A566FDA9AAA1456735E3AEC47B6E53 /* Build configuration list for PBXNativeTarget "wren_test" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E4399D44E7AA6F7669171384 /* Release */,
-				E4399D44E7AA6F7669171384 /* Release */,
-				E4399D44E7AA6F7669171384 /* Release */,
-				4591788AE9E4163CFC1C5ECA /* Debug */,
-				4591788AE9E4163CFC1C5ECA /* Debug */,
-				4591788AE9E4163CFC1C5ECA /* Debug */,
+				E764569CA115B6931532748EC9506F45F861A85BB0EBFCD3 /* Release */,
+				E764569CA115B6931532748EC9506F45F861A85BB0EBFCD3 /* Release */,
+				E764569CA115B6931532748EC9506F45F861A85BB0EBFCD3 /* Release */,
+				F55DF4FCA194E159B2E1CA3AEA05C58B44223EA42EA49799 /* Debug */,
+				F55DF4FCA194E159B2E1CA3AEA05C58B44223EA42EA49799 /* Debug */,
+				F55DF4FCA194E159B2E1CA3AEA05C58B44223EA42EA49799 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -21,6 +21,11 @@
   #include <stdio.h>
 #endif
 
+typedef enum {
+  PREDEF_ALLOCATE = 0,
+  PREDEF_FINALIZE = 1
+} PredefinedSymbol;
+
 // The behavior of realloc() when the size is 0 is implementation defined. It
 // may return a non-NULL pointer which must not be dereferenced but nevertheless
 // should be freed. To prevent that, we avoid calling realloc() with a zero
@@ -39,6 +44,18 @@ static void* defaultReallocate(void* ptr, size_t newSize, void* _)
 int wrenGetVersionNumber() 
 { 
   return WREN_VERSION_NUMBER;
+}
+
+static inline void ensurePredefinedSymbol(WrenVM* vm,
+    const char* name, PredefinedSymbol expectedSymbol) {
+  int symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, name, strlen(name));
+  ASSERT(symbol == expectedSymbol, "Definition of predefined symbols went wrong.");
+}
+
+// This function ensures that the special method symbols are there.
+static void ensurePredefinedSymbols(WrenVM* vm) {
+  ensurePredefinedSymbol(vm, "<allocate>", PREDEF_ALLOCATE);
+  ensurePredefinedSymbol(vm, "<finalize>", PREDEF_FINALIZE);
 }
 
 void wrenInitConfiguration(WrenConfiguration* config)
@@ -90,6 +107,7 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   vm->nextGC = vm->config.initialHeapSize;
 
   wrenSymbolTableInit(&vm->methodNames);
+  ensurePredefinedSymbols(vm);
 
   vm->modules = wrenNewMap(vm);
   wrenInitializeCore(vm);
@@ -588,22 +606,16 @@ static void bindForeignClass(WrenVM* vm, ObjClass* classObj, ObjModule* module)
   Method method;
   method.type = METHOD_FOREIGN;
 
-  // Add the symbol even if there is no allocator so we can ensure that the
-  // symbol itself is always in the symbol table.
-  int symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, "<allocate>", 10);
   if (methods.allocate != NULL)
   {
     method.as.foreign = methods.allocate;
-    wrenBindMethod(vm, classObj, symbol, method);
+    wrenBindMethod(vm, classObj, PREDEF_ALLOCATE, method);
   }
   
-  // Add the symbol even if there is no finalizer so we can ensure that the
-  // symbol itself is always in the symbol table.
-  symbol = wrenSymbolTableEnsure(vm, &vm->methodNames, "<finalize>", 10);
   if (methods.finalize != NULL)
   {
     method.as.foreign = (WrenForeignMethodFn)methods.finalize;
-    wrenBindMethod(vm, classObj, symbol, method);
+    wrenBindMethod(vm, classObj, PREDEF_FINALIZE, method);
   }
 }
 
@@ -660,12 +672,7 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
   ObjClass* classObj = AS_CLASS(stack[0]);
   ASSERT(classObj->numFields == -1, "Class must be a foreign class.");
 
-  // TODO: Don't look up every time.
-  int symbol = wrenSymbolTableFind(&vm->methodNames, "<allocate>", 10);
-  ASSERT(symbol != -1, "Should have defined <allocate> symbol.");
-
-  ASSERT(classObj->methods.count > symbol, "Class should have allocator.");
-  Method* method = &classObj->methods.data[symbol];
+  Method* method = &classObj->methods.data[PREDEF_ALLOCATE];
   ASSERT(method->type == METHOD_FOREIGN, "Allocator should be foreign.");
 
   // Pass the constructor arguments to the allocator as well.
@@ -679,18 +686,9 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
 
 void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign)
 {
-  // TODO: Don't look up every time.
-  int symbol = wrenSymbolTableFind(&vm->methodNames, "<finalize>", 10);
-  ASSERT(symbol != -1, "Should have defined <finalize> symbol.");
-
-  // If there are no finalizers, don't finalize it.
-  if (symbol == -1) return;
-
   // If the class doesn't have a finalizer, bail out.
   ObjClass* classObj = foreign->obj.classObj;
-  if (symbol >= classObj->methods.count) return;
-
-  Method* method = &classObj->methods.data[symbol];
+  Method* method = &classObj->methods.data[PREDEF_FINALIZE];
   if (method->type == METHOD_NONE) return;
 
   ASSERT(method->type == METHOD_FOREIGN, "Finalizer should be foreign.");

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -23,7 +23,8 @@
 
 typedef enum {
   PREDEF_ALLOCATE = 0,
-  PREDEF_FINALIZE = 1
+  PREDEF_TRACE    = 1,
+  PREDEF_FINALIZE = 2,
 } PredefinedSymbol;
 
 // The behavior of realloc() when the size is 0 is implementation defined. It
@@ -55,6 +56,7 @@ static inline void ensurePredefinedSymbol(WrenVM* vm,
 // This function ensures that the special method symbols are there.
 static void ensurePredefinedSymbols(WrenVM* vm) {
   ensurePredefinedSymbol(vm, "<allocate>", PREDEF_ALLOCATE);
+  ensurePredefinedSymbol(vm, "<trace>",    PREDEF_TRACE);
   ensurePredefinedSymbol(vm, "<finalize>", PREDEF_FINALIZE);
 }
 
@@ -582,6 +584,7 @@ static void bindForeignClass(WrenVM* vm, ObjClass* classObj, ObjModule* module)
   WrenForeignClassMethods methods;
   methods.allocate = NULL;
   methods.finalize = NULL;
+  methods.trace    = NULL;
   
   // Check the optional built-in module first so the host can override it.
   
@@ -592,7 +595,7 @@ static void bindForeignClass(WrenVM* vm, ObjClass* classObj, ObjModule* module)
   }
 
   // If the host didn't provide it, see if it's a built in optional module.
-  if (methods.allocate == NULL && methods.finalize == NULL)
+  if (methods.allocate == NULL && methods.finalize == NULL && methods.trace == NULL)
   {
 #if WREN_OPT_RANDOM
     if (strcmp(module->name->value, "random") == 0)
@@ -616,6 +619,13 @@ static void bindForeignClass(WrenVM* vm, ObjClass* classObj, ObjModule* module)
   {
     method.as.foreign = (WrenForeignMethodFn)methods.finalize;
     wrenBindMethod(vm, classObj, PREDEF_FINALIZE, method);
+  }
+
+
+  if (methods.trace != NULL)
+  {
+    method.as.foreign = (WrenForeignMethodFn)methods.trace;
+    wrenBindMethod(vm, classObj, PREDEF_TRACE, method);
   }
 }
 
@@ -682,6 +692,22 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
   method->as.foreign(vm);
 
   vm->apiStack = NULL;
+}
+
+void wrenTraceForeign(WrenVM* vm, ObjForeign* foreign)
+{
+  // If the class doesn't have a tracer, bail out.
+  ObjClass* classObj = foreign->obj.classObj;
+  Method* method = &classObj->methods.data[PREDEF_TRACE];
+  if (method->type == METHOD_NONE) return;
+
+  ASSERT(method->type == METHOD_FOREIGN, "Tracer should be foreign.");
+
+  WrenTracerFn tracer = (WrenTracerFn)method->as.foreign;
+
+  // The tracer pointer is actually just the VM. We use a different type
+  // to make misue require a little effort
+  vm->bytesAllocated += tracer((WrenTracer*) vm, foreign->data);
 }
 
 void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign)
@@ -1720,6 +1746,13 @@ WrenHandle* wrenGetSlotHandle(WrenVM* vm, int slot)
   return wrenMakeHandle(vm, vm->apiStack[slot]);
 }
 
+WrenRawValue wrenGetSlotRawValue(WrenVM* vm, int slot)
+{
+  validateApiSlot(vm, slot);
+  return wrenMakeRawValue(vm, vm->apiStack[slot]);
+}
+
+
 // Stores [value] in [slot] in the foreign call stack.
 static void setSlot(WrenVM* vm, int slot, Value value)
 {
@@ -1785,6 +1818,11 @@ void wrenSetSlotHandle(WrenVM* vm, int slot, WrenHandle* handle)
   ASSERT(handle != NULL, "Handle cannot be NULL.");
 
   setSlot(vm, slot, handle->value);
+}
+
+void wrenSetSlotRawValue(WrenVM* vm, int slot, WrenRawValue rv)
+{
+  setSlot(vm, slot, wrenUnpackRawValue(rv));
 }
 
 int wrenGetListCount(WrenVM* vm, int slot)

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -131,6 +131,9 @@ struct WrenVM
 //   [oldSize] will be zero. It should return NULL.
 void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize);
 
+// Invoke the tracer for the foreign object referenced by [foreign].
+void wrenTraceForeign(WrenVM* vm, ObjForeign* foreign);
+
 // Invoke the finalizer for the foreign object referenced by [foreign].
 void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign);
 

--- a/test/api/api_tests.c
+++ b/test/api/api_tests.c
@@ -46,6 +46,9 @@ WrenForeignMethodFn APITest_bindForeignMethod(
   method = newVMBindMethod(fullName);
   if (method != NULL) return method;
 
+  method = rawValueBindMethod(fullName);
+  if (method != NULL) return method;
+
   method = resolutionBindMethod(fullName);
   if (method != NULL) return method;
 
@@ -68,6 +71,9 @@ WrenForeignClassMethods APITest_bindForeignClass(
   if (strncmp(module, "./test/api", 7) != 0) return methods;
 
   foreignClassBindClass(className, &methods);
+  if (methods.allocate != NULL) return methods;
+
+  rawValueBindClass(className, &methods);
   if (methods.allocate != NULL) return methods;
 
   resetStackAfterForeignConstructBindClass(className, &methods);

--- a/test/api/api_tests.h
+++ b/test/api/api_tests.h
@@ -18,6 +18,7 @@
 #include "lists.h"
 #include "maps.h"
 #include "new_vm.h"
+#include "raw_value.h"
 #include "reset_stack_after_call_abort.h"
 #include "reset_stack_after_foreign_construct.h"
 #include "resolution.h"

--- a/test/api/raw_value.c
+++ b/test/api/raw_value.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "raw_value.h"
+
+static int holderCounter = 0;
+
+typedef struct {
+  WrenRawValue val;
+} RawValueHolder;
+
+
+static void holderAllocate(WrenVM* vm)
+{
+  RawValueHolder* holder = wrenSetSlotNewForeign(vm, 0, 0, sizeof(RawValueHolder));
+  holder->val = wrenNullRawValue();
+  holderCounter++;
+}
+
+static size_t holderTrace(WrenTracer* trace, void* p)
+{
+  RawValueHolder* holder = p;
+  wrenTraceRawValue(trace, holder->val);
+
+  return sizeof(*holder);
+}
+
+
+static void holderFinalizer(void* p)
+{
+  holderCounter--;
+}
+
+static void holderSet(WrenVM* vm)
+{
+  RawValueHolder* holder = wrenGetSlotForeign(vm, 0);
+  holder->val = wrenGetSlotRawValue(vm, 1);
+}
+
+static void holderGet(WrenVM* vm)
+{
+  RawValueHolder* holder = wrenGetSlotForeign(vm, 0);
+  wrenSetSlotRawValue(vm, 0, holder->val);
+}
+
+static void holderCount(WrenVM* vm)
+{
+  wrenSetSlotDouble(vm, 0, (double)holderCounter);
+}
+
+WrenForeignMethodFn rawValueBindMethod(const char* signature)
+{
+  if (strcmp(signature, "RawValueHolder.value") == 0) return holderGet;
+  if (strcmp(signature, "RawValueHolder.value=(_)") == 0) return holderSet;
+  if (strcmp(signature, "static RawValueHolder.count") == 0) return holderCount;
+
+  return NULL;
+}
+
+void rawValueBindClass(
+    const char* className, WrenForeignClassMethods* methods)
+{
+  if (strcmp(className, "RawValueHolder") == 0)
+  {
+    methods->allocate = holderAllocate;
+    methods->trace    = holderTrace;
+    methods->finalize = holderFinalizer;
+  }
+}

--- a/test/api/raw_value.h
+++ b/test/api/raw_value.h
@@ -1,0 +1,6 @@
+#include "wren.h"
+
+
+WrenForeignMethodFn rawValueBindMethod(const char* signature);
+void rawValueBindClass(
+    const char* className, WrenForeignClassMethods* methods);

--- a/test/api/raw_value.wren
+++ b/test/api/raw_value.wren
@@ -1,0 +1,42 @@
+foreign class RawValueHolder {
+  construct new() {}
+  construct new(val) {
+    value = val
+  }
+
+  foreign value
+  foreign value=(rhs)
+  foreign static count
+}
+
+System.print(RawValueHolder.count) // expect: 0
+var h1 = RawValueHolder.new()
+System.print(RawValueHolder.count) // expect: 1
+h1.value = 123
+System.print(h1.value) // expect: 123
+System.gc()
+System.print(h1.value) // expect: 123
+h1.value = "Hello, world!"
+System.print(h1.value) // expect: Hello, world!
+System.gc()
+System.print(h1.value) // expect: Hello, world!
+System.print(RawValueHolder.count) // expect: 1
+h1.value = RawValueHolder.new("Boop")
+System.print(RawValueHolder.count) // expect: 2
+System.print(h1.value.value) // expect: Boop
+System.gc()
+System.print(RawValueHolder.count) // expect: 2
+System.print(h1.value.value) // expect: Boop
+h1.value = null
+System.gc()
+System.print(RawValueHolder.count) // expect: 1
+
+h1.value = RawValueHolder.new()
+h1.value.value = RawValueHolder.new()
+System.print(RawValueHolder.count) // expect: 3
+h1.value = null
+System.gc()
+System.print(RawValueHolder.count) // expect: 1
+h1 = null
+System.gc()
+System.print(RawValueHolder.count) // expect: 0


### PR DESCRIPTION
This MR introduces a "WrenRawValue" abstraction. This is a tricky API, so this PR is in part for discussion.

Firstly, this MR incorporates a rebased version of the changes from #911. Since the new trace hook is called on _every_ garbage collection, this is pretty much necessary to not have horrendous performance issues.

Currently the internal Value representation (NaN boxing or not) is currently not exposed as a part of the ABI, and I wanted to preserve that. Therefore WrenRawValue is defined as a simple union:
```
typedef union WrenRawValue {
  uint64_t  bits;
  void     *ptr;
} WrenRawValue;
```

When NaN boxing is use, we just stuff the NaN boxed value into the `bits` member. When NaN boxing is not in use, we just stuff Object pointers directly into `ptr`. For other value types (Bool, num, etc), we box them by constructing a (newly introduced) ObjIValue to wrap them. The handling of these boxes is entirely contained within the RawValue logic, so the rest of the code need not be concerned.

This MR of course also adds functions to move values between stack slots and WrenRawValues, and one to initialize a RawValue to NULL.

It also adds a trace callback to foreign classes, which is how the GC becomes aware of RawValues. This is the tricky part of the API: it is users' responsibility to properly trace all of their RawValues. 

Things I'm especially interested in commentary on:
 * Is this a direction we want to go? (This kind of interface is definitely something I want for my usage of Wren)
 * Naming (RawValue and ObjIValue), since neither of them make me particularly happy
 * General thoughts on the implementation.

--

One other thing I have considered is an alternate (or even complementary) implementation of this concept where the values are guaranteed pointer sized. This is useful when encapsulating references in C APIs which give a "void *userdata" pointer or similar. This would have a similar implementation, but would necessitate the use of ObjIValue boxing on 32-bit platforms even with NaN tagging. Ideally I think I'd have both for efficiency reasons, but I realize having two complementary ways of doing the same thing (even in the 'advanced APIs' section!) could be confusing