### PR TITLE
Get slot class and class identification

### DIFF
--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -413,6 +413,13 @@ WREN_API void wrenGetSlotClass(WrenVM* vm, int slot, int classSlot);
 // by the caller.
 //
 // This function returns null if there is no class object in [slot].
+//
+// This function is meant for debugging purposes only and should never be used
+// to discriminate a class from another as the caller has no guaranty regarding
+// the origin of the class. To discriminate a class, one should prefer the use
+// of [wrenGetVariable()] followed by [wrenGetSlotClass()] and
+// [wrenIsSameClass()] instead, the first call being the insurance that the
+// class to discrimitate actually comes from the expected module.
 WREN_API const char *wrenGetSlotClassName(WrenVM* vm, int slot);
 
 // Reads a boolean value from [slot].
@@ -554,6 +561,13 @@ WREN_API bool wrenHasVariable(WrenVM* vm, const char* module, const char* name);
 
 // Returns true if [module] has been imported/resolved before, false if not.
 WREN_API bool wrenHasModule(WrenVM* vm, const char* module);
+
+// Returns true if the class in [slotA] is the same as the one in [slotB].
+WREN_API bool wrenIsSameClass(WrenVM* vm, int slotA, int slotB);
+
+// Returns true if the class in [slotA] is the same class or a subclass of
+// the class in [slotB].
+WREN_API bool wrenIsSubClass(WrenVM* vm, int slotA, int slotB);
 
 // Sets the current fiber to be aborted, and uses the value in [slot] as the
 // runtime error object.

--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -401,6 +401,20 @@ WREN_API void wrenEnsureSlots(WrenVM* vm, int numSlots);
 // Gets the type of the object in [slot].
 WREN_API WrenType wrenGetSlotType(WrenVM* vm, int slot);
 
+// Gets the class of the object in [slot] and stores it in [classSlot].
+//
+// If the object in [slot] is a class, it is returned unchanged into
+// [classSlot].
+WREN_API void wrenGetSlotClass(WrenVM* vm, int slot, int classSlot);
+
+// Gets the name of the class in [slot].
+//
+// The string returned is the property of the [vm] so it must not be freed
+// by the caller.
+//
+// This function returns null if there is no class object in [slot].
+WREN_API const char *wrenGetSlotClassName(WrenVM* vm, int slot);
+
 // Reads a boolean value from [slot].
 //
 // It is an error to call this if the slot does not contain a boolean value.

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1673,6 +1673,33 @@ WrenType wrenGetSlotType(WrenVM* vm, int slot)
   return WREN_TYPE_UNKNOWN;
 }
 
+void wrenGetSlotClass(WrenVM* vm, int slot, int classSlot)
+{
+  validateApiSlot(vm, slot);
+  validateApiSlot(vm, classSlot);
+
+  Value value = vm->apiStack[slot];
+
+  if (IS_CLASS(value)) {
+    vm->apiStack[classSlot] = value;
+    return;
+  }
+
+  ObjClass* classObj = wrenGetClass(vm, value);
+
+  vm->apiStack[classSlot] = wrenObjectToValue((Obj*)classObj);
+}
+
+const char *wrenGetSlotClassName(WrenVM* vm, int slot)
+{
+    validateApiSlot(vm, slot);
+
+    Value value = vm->apiStack[slot];
+    if (!IS_CLASS(value)) return NULL;
+
+    return AS_CLASS(value)->name->value;
+}
+
 bool wrenGetSlotBool(WrenVM* vm, int slot)
 {
   validateApiSlot(vm, slot);

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -2003,6 +2003,37 @@ bool wrenHasModule(WrenVM* vm, const char* module)
   return moduleObj != NULL;
 }
 
+bool wrenIsSameClass(WrenVM* vm, int slotA, int slotB)
+{
+  validateApiSlot(vm, slotA);
+  validateApiSlot(vm, slotB);
+  ASSERT(IS_CLASS(vm->apiStack[slotA]), "SlotA must be a class.");
+  ASSERT(IS_CLASS(vm->apiStack[slotB]), "SlotB must be a class.");
+
+  ObjClass* classA = AS_CLASS(vm->apiStack[slotA]);
+  ObjClass* classB = AS_CLASS(vm->apiStack[slotB]);
+
+  return classA == classB;
+}
+
+bool wrenIsSubClass(WrenVM* vm, int slotA, int slotB)
+{
+  validateApiSlot(vm, slotA);
+  validateApiSlot(vm, slotB);
+  ASSERT(IS_CLASS(vm->apiStack[slotA]), "SlotA must be a class.");
+  ASSERT(IS_CLASS(vm->apiStack[slotB]), "SlotB must be a class.");
+
+  ObjClass* classA = AS_CLASS(vm->apiStack[slotA]);
+  ObjClass* classB = AS_CLASS(vm->apiStack[slotB]);
+
+  do {
+    if (classA == classB) return true;
+    classA = classA->superclass;
+  } while (classA != NULL);
+
+  return false;
+}
+
 void wrenAbortFiber(WrenVM* vm, int slot)
 {
   validateApiSlot(vm, slot);

--- a/test/api/slots.c
+++ b/test/api/slots.c
@@ -191,6 +191,37 @@ static void getSlotClassName(WrenVM* vm)
   }
 }
 
+static void isParameterForeignType(WrenVM* vm)
+{
+    // First, get whatever variable is named "ForeignType" in the slots module.
+    wrenGetVariable(vm, "./test/api/slots", "ForeignType", 0);
+
+    // Then, retrieve the class of the variable.
+    wrenGetSlotClass(vm, 0, 0);
+
+    // Then, retrieve the class of the parameter.
+    wrenGetSlotClass(vm, 1, 1);
+
+    // Finally, check that both are "the same".
+    wrenSetSlotBool(vm, 0, wrenIsSameClass(vm, 0, 1));
+}
+
+static void isParameterForeignTypeByName(WrenVM* vm)
+{
+    // First, retrieve the class of the parameter.
+    wrenGetSlotClass(vm, 1, 1);
+
+    // Finally, check that the class is named "ForeignType".
+    //
+    // Please note that this is definitely what you should not do to ensure
+    // you've been given the right parameter class, as the "ForeignType" here
+    // only validates the name and not its origin.
+    // From what we know, the parameter we've been given might come from any
+    // module, "./test/api/slots" or anything else.
+    const char* name = wrenGetSlotClassName(vm, 1);
+    wrenSetSlotBool(vm, 0, strcmp(name, "ForeignType") == 0);
+}
+
 WrenForeignMethodFn slotsBindMethod(const char* signature)
 {
   if (strcmp(signature, "static Slots.noSet") == 0) return noSet;
@@ -204,6 +235,8 @@ WrenForeignMethodFn slotsBindMethod(const char* signature)
   if (strcmp(signature, "static Slots.getMapValue(_,_)") == 0) return getMapValue;
   if (strcmp(signature, "static Slots.getSlotClass(_)") == 0) return getSlotClass;
   if (strcmp(signature, "static Slots.getSlotClassName(_)") == 0) return getSlotClassName;
+  if (strcmp(signature, "static Slots.isParameterForeignType(_)") == 0) return isParameterForeignType;
+  if (strcmp(signature, "static Slots.isParameterForeignTypeByName(_)") == 0) return isParameterForeignTypeByName;
 
   return NULL;
 }

--- a/test/api/slots.c
+++ b/test/api/slots.c
@@ -172,6 +172,25 @@ static void getMapValue(WrenVM* vm)
   wrenGetMapValue(vm, 1, 2, 0);
 }
 
+static void getSlotClass(WrenVM* vm)
+{
+  wrenGetSlotClass(vm, 1, 0);
+}
+
+static void getSlotClassName(WrenVM* vm)
+{
+  const char* name = wrenGetSlotClassName(vm, 1);
+
+  if (name == NULL)
+  {
+    wrenSetSlotNull(vm, 0);
+  }
+  else
+  {
+    wrenSetSlotString(vm, 0, name);
+  }
+}
+
 WrenForeignMethodFn slotsBindMethod(const char* signature)
 {
   if (strcmp(signature, "static Slots.noSet") == 0) return noSet;
@@ -183,6 +202,8 @@ WrenForeignMethodFn slotsBindMethod(const char* signature)
   if (strcmp(signature, "static Slots.getListCount(_)") == 0) return getListCount;
   if (strcmp(signature, "static Slots.getListElement(_,_)") == 0) return getListElement;
   if (strcmp(signature, "static Slots.getMapValue(_,_)") == 0) return getMapValue;
+  if (strcmp(signature, "static Slots.getSlotClass(_)") == 0) return getSlotClass;
+  if (strcmp(signature, "static Slots.getSlotClassName(_)") == 0) return getSlotClassName;
 
   return NULL;
 }

--- a/test/api/slots.wren
+++ b/test/api/slots.wren
@@ -8,6 +8,8 @@ class Slots {
   foreign static getListCount(list)
   foreign static getListElement(list, index)
   foreign static getMapValue(map, key)
+  foreign static getSlotClass(obj)
+  foreign static getSlotClassName(obj)
 }
 
 foreign class ForeignType {
@@ -49,3 +51,29 @@ var capitals = {
 System.print(Slots.getMapValue(capitals, "England")) // expect: London
 System.print(Slots.getMapValue(capitals, "Wales")) // expect: Cardiff
 System.print(Slots.getMapValue(capitals, "S. Ireland")) // expect: null
+
+System.print(Slots.getSlotClass(Slots)) // expect: Slots
+System.print(Slots.getSlotClass(ForeignType)) // expect: ForeignType
+System.print(Slots.getSlotClass(ForeignType.new())) // expect: ForeignType
+System.print(Slots.getSlotClass(capitals)) // expect: Map
+System.print(Slots.getSlotClass([])) // expect: List
+
+// If a class is given, returns the name of the class.
+// If anything but a class is given, returns null.
+System.print(Slots.getSlotClassName(Class)) // expect: Class
+System.print(Slots.getSlotClassName(Slots)) // expect: Slots
+System.print(Slots.getSlotClassName(Map)) // expect: Map
+System.print(Slots.getSlotClassName(capitals)) // expect: null
+System.print(Slots.getSlotClassName(Slots.getSlotClass(capitals)))
+// expect: Map
+System.print(Slots.getSlotClassName(ducks)) // expect: null
+System.print(Slots.getSlotClassName(Slots.getSlotClass(ducks))) // expect: List
+System.print(Slots.getSlotClassName(Bool)) // expect: Bool
+System.print(Slots.getSlotClassName(true)) // expect: null
+System.print(Slots.getSlotClassName(Slots.getSlotClass(true))) // expect: Bool
+System.print(Slots.getSlotClassName(Null)) // expect: Null
+// The "null" is misleading as one might think it returns the value it
+// has been given, but this is correct behavior as the given "null" is not
+// a class, but instead a class instance: it is the second case above.
+System.print(Slots.getSlotClassName(null)) // expect: null
+System.print(Slots.getSlotClassName(Slots.getSlotClass(null))) // expect: Null

--- a/test/api/slots.wren
+++ b/test/api/slots.wren
@@ -10,6 +10,8 @@ class Slots {
   foreign static getMapValue(map, key)
   foreign static getSlotClass(obj)
   foreign static getSlotClassName(obj)
+  foreign static isParameterForeignType(param)
+  foreign static isParameterForeignTypeByName(param)
 }
 
 foreign class ForeignType {
@@ -77,3 +79,16 @@ System.print(Slots.getSlotClassName(Null)) // expect: Null
 // a class, but instead a class instance: it is the second case above.
 System.print(Slots.getSlotClassName(null)) // expect: null
 System.print(Slots.getSlotClassName(Slots.getSlotClass(null))) // expect: Null
+
+System.print(Slots.isParameterForeignType(Slots)) // expect: false
+System.print(Slots.isParameterForeignType(ForeignType)) // expect: true
+System.print(Slots.isParameterForeignType(ForeignType.new())) // expect: true
+System.print(Slots.isParameterForeignType(Bool)) // expect: false
+System.print(Slots.isParameterForeignType(true)) // expect: false
+
+System.print(Slots.isParameterForeignTypeByName(Slots)) // expect: false
+System.print(Slots.isParameterForeignTypeByName(ForeignType)) // expect: true
+System.print(Slots.isParameterForeignTypeByName(ForeignType.new()))
+// expect: true
+System.print(Slots.isParameterForeignTypeByName(Bool)) // expect: false
+System.print(Slots.isParameterForeignTypeByName(true)) // expect: false


### PR DESCRIPTION
This PR implements a few functions in the C API to:
* get the class of a value at a specific slot ;
* compare two classes for equality or inheritance ;

Some of these functions were initially discussed and implemented in https://github.com/wren-lang/wren/pull/591 but were eventually abandoned by the developer of the PR.

I have been in need for these for the following use case:
* say we have several foreign classes in the `enchantment` module, how does `Wizard.enchant(_)` can be certain it is been given a `Unicorn` and not an `Orc` as parameter ? The `Wizard` must use the foreign pointer of the `Unicorn` in order to enchant it, but if it is given another class instance, bad things would happen : allowing the developer to validate the parameters would be nice ;
* how do we know it is given a `Unicorn` from `enchantment` and not from `upside_down` ? Both use different foreign pointer types and APIs : allowing the developer to tell the origin of a class would be nice ;
* sometimes, we just need to know the name of what we are given, so having the name of the class could be useful too ;

This PR has been tested (with make only):
* `debug_64bit` with tests (`--suffix _d`) :white_check_mark: ;
* `debug_64bit-no-nan-tagging` with tests (`--suffix _d`) :white_check_mark: ;
* `release_64bit-no-nan-tagging` with tests :white_check_mark: ;
* `release_64bit-no-nan-tagging` with tests :white_check_mark: ;

There is a point that might need improvements:
* the procedure in `isParameterForeignType` (in the tests) is useful but quite long to be copied in basically any foreign class we want to validate the parameters of : I was thinking that having a function to do it (possibly without using any slot apart from the source, `bool wrenIsSlotSameClassAs(WrenVM* vm, int slot, const char* module, const char* className`) would be nice to have ;