### PR TITLE
Specialize `Range.contains(_)`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,4 +29,4 @@ ruby0x1 <ruby0x1@pm.me>
 Kolja Kube <code@koljaku.be>
 Alexander Klingenbeck <alexander.klingenbeck@gmx.de>
 Aviv Beeri <avbeeri@gmail.com>
-
+Masa Maeda <masamaedae@gmail.com>

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -919,6 +919,24 @@ DEF_PRIMITIVE(range_max)
   RETURN_NUM(fmax(range->from, range->to));
 }
 
+DEF_PRIMITIVE(range_contains)
+{
+  ObjRange* range = AS_RANGE(args[0]);
+
+  if (!validateNum(vm, args[1], "Element")) return false;
+  double num = AS_NUM(args[1]);
+
+  // If it's an empty range it can't contain any value
+  if (range->from == range->to && !range->isInclusive) RETURN_FALSE;
+  // Handle the inclusive case
+  if (!range->isInclusive && num == range->to) RETURN_TRUE;
+
+  double min = fmin(range->from, range->to);
+  double max = fmax(range->from, range->to);
+
+  RETURN_BOOL(num > min && num < max);
+}
+
 DEF_PRIMITIVE(range_isInclusive)
 {
   RETURN_BOOL(AS_RANGE(args[0])->isInclusive);
@@ -1463,6 +1481,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->rangeClass, "min", range_min);
   PRIMITIVE(vm->rangeClass, "max", range_max);
   PRIMITIVE(vm->rangeClass, "isInclusive", range_isInclusive);
+  PRIMITIVE(vm->rangeClass, "contains", range_contains);
   PRIMITIVE(vm->rangeClass, "iterate(_)", range_iterate);
   PRIMITIVE(vm->rangeClass, "iteratorValue(_)", range_iteratorValue);
   PRIMITIVE(vm->rangeClass, "toString", range_toString);

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -1481,7 +1481,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->rangeClass, "min", range_min);
   PRIMITIVE(vm->rangeClass, "max", range_max);
   PRIMITIVE(vm->rangeClass, "isInclusive", range_isInclusive);
-  PRIMITIVE(vm->rangeClass, "contains", range_contains);
+  PRIMITIVE(vm->rangeClass, "contains(_)", range_contains);
   PRIMITIVE(vm->rangeClass, "iterate(_)", range_iterate);
   PRIMITIVE(vm->rangeClass, "iteratorValue(_)", range_iteratorValue);
   PRIMITIVE(vm->rangeClass, "toString", range_toString);


### PR DESCRIPTION
Creates a specialization for `Range.contains(_)` that is a bound check rather than using `Sequence`'s implementation which uses iteration instead.

This came up when I was implementing some Project Euler stuff when and I noticed the pathological behavior in some of those problems as well. Particularly problem 17 was about 1000x slower using ranges (I had like 6 different ranges).

I didn't add any new tests since this method is pretty extensively covered. I did create a pathological benchmark for it though. 

Benchmark included below uses `./bin/wren_test`. I wasn't sure if I should include it in the benchmarks folder since it looks like that is for comparing against different languages.

Looks like it's roughly 300x faster in this pathological case, but I reran it for `(0...10)` and it still is about 5x faster. 

Anyway, let me know if I should change anything here! This isn't too big of a change and I think it can help all users of the language. 

```wren
var start = System.clock
var total = 0
for (i in 0..1e5) {
    if ((0...1e3).contains(i)) {
        total = total + 1
    }
}
System.print(total)
System.print("elapsed: %(System.clock - start)")

// Before
// 1000
// elapsed: 2.968864

// After
// 1000
// elapsed: 0.010275
```