### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/site/getting-started.markdown
+++ b/doc/site/getting-started.markdown
@@ -49,6 +49,20 @@ If your platform isn't explicitly supported,
 it is recommended that you include the Wren source
 in your project for a portable experience.
 
+### Building Wren from vcpkg
+
+The wren port in [vcpkg](https://github.com/Microsoft/vcpkg) is kept up to date by Microsoft team members and community contributors. You can download and install wren using the vcpkg dependency manager:
+
+```shell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install wren
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Including the code in your project
 
 **all source files**   


### PR DESCRIPTION
Wren is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for wren and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build wren, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/wren/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.