### PR TITLE
docs: add link to cli in mobile view

### DIFF
--- a/doc/site/template.html
+++ b/doc/site/template.html
@@ -100,6 +100,7 @@
         <td>
           <ul>
             <li><a href="modules">API/Modules</a></li>
+            <li><a href="cli">Wren CLI</a></li>
             <li><a href="embedding">Embedding</a></li>
             <li><a href="performance.html">Performance</a></li>
             <li><a href="qa.html">Q &amp; A</a></li>


### PR DESCRIPTION
the link is currently missing, there is no chance to navigate to the cli subpage from the links