### PR TITLE
Add `Object.hash`

### DIFF
--- a/doc/site/modules/core/object.markdown
+++ b/doc/site/modules/core/object.markdown
@@ -29,6 +29,10 @@ Compares two objects using built-in equality. This compares [value
 types](../../values.html) by value, and all other objects are compared by
 identity&mdash;two objects are equal only if they are the exact same object.
 
+### **hash**
+
+Returns a hash of the object.
+
 ### **is**(class) operator
 
 Returns `true` if this object's class or one of its superclasses is `class`.

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -885,6 +885,11 @@ DEF_PRIMITIVE(object_is)
   RETURN_BOOL(false);
 }
 
+DEF_PRIMITIVE(object_hash)
+{
+  RETURN_NUM(wrenHash(args[0]));
+}
+
 DEF_PRIMITIVE(object_toString)
 {
   Obj* obj = AS_OBJ(args[0]);
@@ -1247,6 +1252,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->objectClass, "!", object_not);
   PRIMITIVE(vm->objectClass, "==(_)", object_eqeq);
   PRIMITIVE(vm->objectClass, "!=(_)", object_bangeq);
+  PRIMITIVE(vm->objectClass, "hash", object_hash);
   PRIMITIVE(vm->objectClass, "is(_)", object_is);
   PRIMITIVE(vm->objectClass, "toString", object_toString);
   PRIMITIVE(vm->objectClass, "type", object_type);

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -420,14 +420,13 @@ static uint32_t hashObject(Obj* object)
       return ((ObjString*)object)->hash;
 
     default:
-      ASSERT(false, "Only immutable objects can be hashed.");
-      return 0;
+      return hashBits((uintptr_t)object);
   }
 }
 
 // Generates a hash code for [value], which must be one of the built-in
 // immutable types: null, bool, class, num, range, or string.
-static uint32_t hashValue(Value value)
+uint32_t wrenHash(Value value)
 {
   // TODO: We'll probably want to randomize this at some point.
 
@@ -464,7 +463,7 @@ static bool findEntry(MapEntry* entries, uint32_t capacity, Value key,
   
   // Figure out where to insert it in the table. Use open addressing and
   // basic linear probing.
-  uint32_t startIndex = hashValue(key) % capacity;
+  uint32_t startIndex = wrenHash(key) % capacity;
   uint32_t index = startIndex;
   
   // If we pass a tombstone and don't end up finding the key, its entry will

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -694,6 +694,8 @@ ObjMap* wrenNewMap(WrenVM* vm);
 // This separation exists to aid the API in surfacing errors to the developer as well.
 static inline bool wrenMapIsValidKey(Value arg);
 
+uint32_t wrenHash(Value value);
+
 // Looks up [key] in [map]. If found, returns the value. Otherwise, returns
 // `UNDEFINED_VAL`.
 Value wrenMapGet(ObjMap* map, Value key);


### PR DESCRIPTION
The basic rationnale is to offer a fast access to the hash of the interal objects, so users can implement their containers more easily and efficiently.

In addition, it also allow regular objects to be hashed by their reference. It allows to have access to a fast hash for objects meant to be unique instances (where `==` does not need to be overloaded).

`Map` behaviour is preserved by `wrenMapIsValidKey` checking we don't try to pass invalid key values. (Not preserving this behaviour would be to complex, and would require reentrancy...)