### PR TITLE
Document System.write/print(object) return value

### DIFF
--- a/doc/site/modules/core/system.markdown
+++ b/doc/site/modules/core/system.markdown
@@ -28,6 +28,8 @@ the object is converted to a string by calling `toString` on it.
 System.print("I like bananas") //> I like bananas
 </pre>
 
+Also returns `object`.
+
 ### System.**printAll**(sequence)
 
 Iterates over `sequence` and prints each element, then prints a single newline
@@ -48,6 +50,8 @@ System.write(4 + 5) //> 9
 
 In the above example, the result of `4 + 5` is printed, and then the prompt is
 printed on the same line because no newline character was printed afterwards.
+
+Also returns `object`.
 
 ### System.**writeAll**(sequence)
 


### PR DESCRIPTION
Although `System.Write(object)` and `System.print(object)` both return their arguments, which is useful for method chaining etc., this isn't documented. The aim of this PR is therefore to remedy that.