### PR TITLE
add unary + operator

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1726,7 +1726,7 @@ typedef enum
   PREC_RANGE,         // .. ...
   PREC_TERM,          // + -
   PREC_FACTOR,        // * / %
-  PREC_UNARY,         // unary - ! ~
+  PREC_UNARY,         // unary - + ! ~
   PREC_CALL,          // . () []
   PREC_PRIMARY
 } Precedence;
@@ -2763,7 +2763,7 @@ GrammarRule rules[] =
   /* TOKEN_SLASH         */ INFIX_OPERATOR(PREC_FACTOR, "/"),
   /* TOKEN_PERCENT       */ INFIX_OPERATOR(PREC_FACTOR, "%"),
   /* TOKEN_HASH          */ UNUSED,
-  /* TOKEN_PLUS          */ INFIX_OPERATOR(PREC_TERM, "+"),
+  /* TOKEN_PLUS          */ OPERATOR("+"),
   /* TOKEN_MINUS         */ OPERATOR("-"),
   /* TOKEN_LTLT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, "<<"),
   /* TOKEN_GTGT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, ">>"),

--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -697,6 +697,7 @@ DEF_NUM_FN(ceil,    ceil)
 DEF_NUM_FN(cos,     cos)
 DEF_NUM_FN(floor,   floor)
 DEF_NUM_FN(negate,  -)
+DEF_NUM_FN(positive,+)
 DEF_NUM_FN(round,   round)
 DEF_NUM_FN(sin,     sin)
 DEF_NUM_FN(sqrt,    sqrt)
@@ -1380,6 +1381,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->numClass, "cos", num_cos);
   PRIMITIVE(vm->numClass, "floor", num_floor);
   PRIMITIVE(vm->numClass, "-", num_negate);
+  PRIMITIVE(vm->numClass, "+", num_positive);
   PRIMITIVE(vm->numClass, "round", num_round);
   PRIMITIVE(vm->numClass, "min(_)", num_min);
   PRIMITIVE(vm->numClass, "max(_)", num_max);


### PR DESCRIPTION
Added a unary '+' operator (`+variable`) to provide symmetry with the unary '-' operator (`-variable`).   These operators are supported by most languages, so makes sense to include.   Although unary '+' is effectively a NOP, it provides clarity in coding situations where want to contrast with the negation, where one may have code applying + and - to some magnitude.

In scripting often have symmetric rules, such as:

```
static rule_type1(alpha, beta, threshold1, threshold2) {
    return (alpha > -threshold) && (beta < +threshold2)
}
static rule_type2(alpha, beta, threshold1, threshold2) {
    return (alpha < +threshold) && (beta > -threshold2)
}
```
Clarifying + and - magnitude clarifies the rules for us.