### PR TITLE
Mark a functions module as reachable for the GC

### DIFF
--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -1089,6 +1089,9 @@ static void blackenFn(WrenVM* vm, ObjFn* fn)
   // Mark the constants.
   wrenGrayBuffer(vm, &fn->constants);
 
+  // Mark the module it belogs to, in case it's been unloaded.
+  wrenGrayObj(vm, fn->module);
+
   // Keep track of how much memory is still in use.
   vm->bytesAllocated += sizeof(ObjFn);
   vm->bytesAllocated += sizeof(uint8_t) * fn->code.capacity;

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -1089,7 +1089,7 @@ static void blackenFn(WrenVM* vm, ObjFn* fn)
   // Mark the constants.
   wrenGrayBuffer(vm, &fn->constants);
 
-  // Mark the module it belogs to, in case it's been unloaded.
+  // Mark the module it belongs to, in case it's been unloaded.
   wrenGrayObj(vm, fn->module);
 
   // Keep track of how much memory is still in use.


### PR DESCRIPTION
i was thinking of this issue https://github.com/wren-lang/wren/issues/791 when i noticed a functions module is not marked as reachable for the GC

this is my first wren PR, so take with that grain of salt but this *should* allow modules to be removed without any bad side effects.
