### PR TITLE
Fix dangling pointer when stack is reallocated during foreign function call often leading to use-after-free. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,4 +30,5 @@ Kolja Kube <code@koljaku.be>
 Alexander Klingenbeck <alexander.klingenbeck@gmx.de>
 Aviv Beeri <avbeeri@gmail.com>
 Mai Lapyst <floss@lapyst.dev>
+Alain Daniel Herrera García <filedelta@proton.me>
 

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1074,7 +1074,19 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
           break;
 
         case METHOD_FOREIGN:
+          Value* oldStack = fiber->stack;
           callForeign(vm, fiber, method->as.foreign, numArgs);
+
+          // A foreign function may call wrenEnsureSlots, which calls
+          // wrenEnsureStack and reallocates the stack, and so may change its
+          // base address.
+          // This means that stackStart has to be updated to the value rebased
+          // by wrenEnsureSlots and that args has to be updated as well.
+          if (fiber->stack != oldStack){
+            stackStart = frame->stackStart;
+            args = fiber->stackTop - numArgs;
+          }
+
           if (wrenHasError(fiber)) RUNTIME_ERROR();
           break;
 


### PR DESCRIPTION
When a foreign function calls wrenEnsureSlots, this calls wrenEnsureStack, which may reallocate a fiber's stack and this may change its address.

When this happens, wrenEnsureStack correctly fixes most of the references to the previous stack location. However, within runInterpreter, the frame's previous stackStart is still stored as a local variable, and args is still based on the previous fiber->stackTop.

This updates stackStart and args to their correct values if fiber->stack has changed after said call.

This PR should fix issue #1185.